### PR TITLE
Add artifacthub-repo.yml for official helm chart

### DIFF
--- a/artifacthub-repo.yml
+++ b/artifacthub-repo.yml
@@ -1,0 +1,8 @@
+repositoryID: 4d7c66ad-67de-41a6-8d84-72642ef17ba5
+owners:
+  - name: Bob van Luijt
+    email: bob@weaviate.io
+  - name: Andrzej Liszka
+    email: andrzej@weaviate.io
+  - name: Sam Stoelinga
+    email: sammiestoel@gmail.com


### PR DESCRIPTION
This will allow us to have a listing on artifacthub.io and have an official and verified publisher badge

This is the helm repo listing that was created: https://artifacthub.io/packages/helm/weaviate/weaviate

I can transfer the listing to weaviate org after someone from weaviate team creates the weaviate org in artifacthub.io