### PR TITLE
Update the chart README

### DIFF
--- a/weaviate/README.md
+++ b/weaviate/README.md
@@ -1,19 +1,13 @@
 # Weaviate
 
-[Weaviate](https://www.semi.network/products/weaviate.html) is a decentralised vector search engine.
+[Weaviate](https://weaviate.io) is a decentralised vector search engine.
 
-## TL;DR
+Please visit the [official docs](https://weaviate.io/developers/weaviate/installation/kubernetes)
+to learn how to install Weaviate on K8s using helm.
+
+## Install
 
 ```bash
-$ helm package .
-$ helm install weaviate ./weaviate.tgz
+helm repo add weaviate https://weaviate.github.io/weaviate-helm
+helm install my-weaviate weaviate/weaviate
 ```
-
-## Introduction
-
-This chart installs weaviate along with it's dependancies (default: etcd) on a [Kubernetes](http://kubernetes.io) cluster using the [Helm](https://helm.sh) package manager.
-
-## Prerequisites
-
-- Kubernets 1.8+
-- PV provisioner support in the underlying infrastructure


### PR DESCRIPTION
The chart README will be shown here: https://artifacthub.io/packages/helm/weaviate/weaviate

It was due for an update since it also referred to semi.technology and had old instructions on how to install the helm chart