### PR TITLE
StatefulSet set serviceName to headless svc

### DIFF
--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -9,7 +9,7 @@ metadata:
     app.kubernetes.io/managed-by: helm
 spec:
   replicas: {{ .Values.replicas }}
-  serviceName: {{ .Values.service.name }}
+  serviceName: {{ .Values.service.name }}-headless
   selector:
     matchLabels:
       app: weaviate


### PR DESCRIPTION
Previously the serviceName was incorrectly set to the weaviate service however that makes it not possible to use the stable networking ID properties of the StatefulSet.

This change fixes it by pointing the StatefulSet.serviceName to point to the weaviate-headless service instead

Fixes #124 