### PR TITLE
Define prometheus service monitor to scrape metrics

### DIFF
--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -181,5 +181,9 @@ function check_creates_template() {
   _settingScrapePromMetrics="--set env.PROMETHEUS_MONITORING_ENABLED=true --set serviceMonitor.enabled=true"
   check_setting_has_value "$_settingScrapePromMetrics" "name: metrics" "containerPort: 2112"
   check_setting_has_value "$_settingScrapePromMetrics" "apiVersion: monitoring.coreos.com/v1" "kind: ServiceMonitor"
+  check_setting_has_value "--set env.PROMETHEUS_MONITORING_ENABLED=true --set serviceMonitor.enabled=false" "name: metrics" "containerPort: 2112"
+  check_no_setting "--set env.PROMETHEUS_MONITORING_ENABLED=false --set serviceMonitor.enabled=true" "kind: ServiceMonitor"
+  check_no_setting "--set env.PROMETHEUS_MONITORING_ENABLED=false --set serviceMonitor.enabled=false" "kind: ServiceMonitor"
+
   echo "Tests successful."
 )

--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -178,5 +178,8 @@ function check_creates_template() {
   check_string_existence "--set modules.text2vec-transformers.passageQueryServices.$modtransformers.enabled=true --set modules.text2vec-transformers.passageQueryServices.$modtransformers.readinessProbe.periodSeconds=988888888888" "periodSeconds: 988888888888"
   done
 
+  _settingScrapePromMetrics="--set env.PROMETHEUS_MONITORING_ENABLED=true --set serviceMonitor.enabled=true"
+  check_setting_has_value "$_settingScrapePromMetrics" "name: metrics" "containerPort: 2112"
+  check_setting_has_value "$_settingScrapePromMetrics" "apiVersion: monitoring.coreos.com/v1" "kind: ServiceMonitor"
   echo "Tests successful."
 )

--- a/weaviate/Chart.yaml
+++ b/weaviate/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 16.4.0
+version: 16.3.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/weaviate/Chart.yaml
+++ b/weaviate/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 16.3.0
+version: 16.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/weaviate/templates/weaviateServiceMonitor.yaml
+++ b/weaviate/templates/weaviateServiceMonitor.yaml
@@ -12,7 +12,8 @@ spec:
   jobLabel: weaviate
   selector:
     matchLabels:
-      app: weaviate
+      app.kubernetes.io/name: weaviate
+      app.kubernetes.io/managed-by: helm
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}

--- a/weaviate/templates/weaviateServiceMonitor.yaml
+++ b/weaviate/templates/weaviateServiceMonitor.yaml
@@ -18,8 +18,8 @@ spec:
     matchNames:
       - {{ .Release.Namespace | quote }}
   endpoints:
-  - targetPort: {{ .Values.serviceMonitor.port }}
-    path: {{ .Values.serviceMonitor.path }}
+  - targetPort: metrics
+    path: /metrics
     interval: {{ .Values.serviceMonitor.interval }}
     scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
 {{- end }}

--- a/weaviate/templates/weaviateServiceMonitor.yaml
+++ b/weaviate/templates/weaviateServiceMonitor.yaml
@@ -1,0 +1,24 @@
+{{- if and .Values.env.PROMETHEUS_MONITORING_ENABLED .Values.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: weaviate
+  labels:
+    name: weaviate
+    app: weaviate
+    app.kubernetes.io/name: weaviate
+    app.kubernetes.io/managed-by: helm
+spec:
+  jobLabel: weaviate
+  selector:
+    matchLabels:
+      app: weaviate
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace | quote }}
+  endpoints:
+  - targetPort: {{ .Values.serviceMonitor.port }}
+    path: {{ .Values.serviceMonitor.path }}
+    interval: {{ .Values.serviceMonitor.interval }}
+    scrapeTimeout: {{ .Values.serviceMonitor.scrapeTimeout }}
+{{- end }}

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -177,7 +177,7 @@ env:
   GOGC: 100
 
   # Expose metrics on port 2112 for Prometheus to scrape
-  PROMETHEUS_MONITORING_ENABLED: true
+  PROMETHEUS_MONITORING_ENABLED: false
 
   # Set a MEM limit for the Weaviate Pod so it can help you both increase GC-related 
   # performance as well as avoid GC-related out-of-memory (“OOM”) situations

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -83,8 +83,6 @@ service:
 # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor
 serviceMonitor:
   enabled: false
-  port: metrics
-  path: /metrics
   interval: 30s
   scrapeTimeout: 10s
 

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -79,6 +79,15 @@ service:
   clusterIP:
   annotations: {}
 
+# The service monitor defines prometheus monitoring for a set of services
+# https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor
+serviceMonitor:
+  enabled: false
+  port: metrics
+  path: /metrics
+  interval: 30s
+  scrapeTimeout: 10s
+
 # Adjust liveness, readiness and startup probes configuration
 startupProbe:
   # For kubernetes versions prior to 1.18 startupProbe is not supported thus can be disabled.
@@ -168,7 +177,7 @@ env:
   GOGC: 100
 
   # Expose metrics on port 2112 for Prometheus to scrape
-  PROMETHEUS_MONITORING_ENABLED: false
+  PROMETHEUS_MONITORING_ENABLED: true
 
   # Set a MEM limit for the Weaviate Pod so it can help you both increase GC-related 
   # performance as well as avoid GC-related out-of-memory (“OOM”) situations


### PR DESCRIPTION
Define `serviceMonitor` prometheus CRD resource to scrape metrics (disabled by default). Here is the rendered manifest:
```
helm template . --set env.PROMETHEUS_MONITORING_ENABLED=true --set serviceMonitor.enabled=true
...
---
# Source: weaviate/templates/weaviateServiceMonitor.yaml
apiVersion: monitoring.coreos.com/v1
kind: ServiceMonitor
metadata:
  name: weaviate
  labels:
    name: weaviate
    app: weaviate
    app.kubernetes.io/name: weaviate
    app.kubernetes.io/managed-by: helm
spec:
  jobLabel: weaviate
  selector:
    matchLabels:
      app.kubernetes.io/name: weaviate
      app.kubernetes.io/managed-by: helm
  namespaceSelector:
    matchNames:
      - "weaviate"
  endpoints:
  - targetPort: metrics
    path: /metrics
    interval: 30s
    scrapeTimeout: 10s
```