### PR TITLE
fix init container

### DIFF
--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -42,7 +42,7 @@ spec:
           privileged: true
         image: "{{ .image.registry }}/{{ .image.repo }}:{{ .image.tag }}"
         imagePullPolicy: "{{ .image.pullPolicy }}"
-        command: ["sysctl", "-w", "vm.max_map_count={{ .sysctlVmMaxMapCount }}", "-w", "vm.overcommit_memory=1" ]
+        command: ["sysctl", "vm.max_map_count={{ .sysctlVmMaxMapCount }}", "vm.overcommit_memory=1" ]
       {{- end }}
       {{- end }}
       {{- if .Values.initContainers.extraInitContainers }}


### PR DESCRIPTION
[-w is defined as](https://man7.org/linux/man-pages/man8/sysctl.8.html):

>        -w, --write
>               Use this option when all arguments prescribe a key to be set.

Which is not the case and currently breaks container init.