### PR TITLE
Allow extra volumes and volumeMounts in the weaviate StatefulSet

### DIFF
--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -175,6 +175,9 @@ function check_creates_template() {
   check_string_existence "--set initContainers.extraInitContainers[0].name=test-init-container " "name: test-init-container"
   check_string_existence "--set initContainers.sysctlInitContainer.enabled=false --set initContainers.extraInitContainers[0].name=test-init-container " "name: test-init-container"
 
+  check_string_existence "--set extraVolumes[0].name=test-extra-volume" "name: test-extra-volume"
+  check_string_existence "--set extraVolumeMounts[0].name=test-extra-volumemount" "name: test-extra-volumemount"
+
   check_string_existence "--set securityContext.thisIsATest=true " "thisIsATest: true"
   check_string_existence "" "imagePullPolicy: IfNotPresent"
   check_setting_has_value "--set image.pullSecrets[0]=weaviate-image-pull-secret" "imagePullSecrets" "name: weaviate-image-pull-secret"

--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -341,6 +341,9 @@ spec:
               {{- end }}
             {{- end }}
           {{- end }}
+          {{ with .Values.extraVolumeMounts }}
+            {{ toYaml . | nindent 10 }}
+          {{- end }}
         {{- if .Values.startupProbe.enabled }}
         startupProbe:
           httpGet:
@@ -391,6 +394,9 @@ spec:
             - key: GOOGLE_APPLICATION_CREDENTIALS
               path: credentials.json
           {{- end }}
+        {{- end }}
+        {{ with .Values.extraVolumes }}
+          {{ toYaml . | nindent 8 }}
         {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -1455,6 +1455,10 @@ custom_config_map:
 # Pass any annotations to Weaviate pods
 annotations:
 
+extraVolumeMounts:
+
+extraVolumes:
+
 nodeSelector:
 
 tolerations:


### PR DESCRIPTION
For a project we keep our secrets in AWS, and parse them as kubernetes secrets with the secret store CSI driver (https://secrets-store-csi-driver.sigs.k8s.io). For this to actually work you need a volume and volumeMount that use this driver to make sure the secrets are fetched from AWS, en the secret resource is created. 
Since we want to use an AWS stored secret for the AUTHENTICATION_APIKEY_ALLOWED_KEYS, env var, we thus need a pod with the mentioned volume and volumeMount. 

We now circumvent this issue by just spinning up a pod with the required volume, which is indefinitely sleeping, but it would probably be cleaner if we could just add it to the Weaviate StatefulSet. 

So hereby a PR to add functionality to allow any number of extra volumes or volumeMounts.
