### PR TITLE
helm chart now using existing pvc

### DIFF
--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -318,7 +318,7 @@ spec:
         volumeMounts:
           - name: weaviate-config
             mountPath: /weaviate-config
-          - name: weaviate-data
+          - name: {{ if .Values.storage.fullnameOverride }}pvc-mount{{ else }}weaviate-data{{ end }}
             mountPath: /var/lib/weaviate
           {{- if index .Values "backups" "gcs" "enabled" }}
             {{- if or (index .Values "backups" "gcs" "secrets") (index .Values "backups" "gcs" "envSecrets") }}
@@ -359,6 +359,11 @@ spec:
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
       volumes:
+        {{- if .Values.storage.fullnameOverride }}
+        - name: pvc-mount
+          persistentVolumeClaim:
+            claimName: {{ .Values.storage.fullnameOverride }}
+        {{- end }}
         - name: weaviate-config
           configMap:
             {{ if .Values.custom_config_map.enabled }}name: {{ .Values.custom_config_map.name }} {{ else }}name: weaviate-config{{ end }}
@@ -392,7 +397,7 @@ spec:
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}
-
+  {{- if not .Values.storage.fullnameOverride }}
   volumeClaimTemplates:
   - metadata:
       name: weaviate-data
@@ -405,3 +410,4 @@ spec:
       resources:
         requests:
           storage: {{ .Values.storage.size }}
+  {{- end }}


### PR DESCRIPTION
Fixed this issue https://forum.weaviate.io/t/cannot-bind-to-existing-pvc/598/2

The docs in [values.yaml](https://github.com/weaviate/weaviate-helm/blob/2ec5e0a4839ed96b668942b1420850b136755660/weaviate/values.yaml#L86C1-L86C1) state: 
```
# The Persistent Volume Claim settings for Weaviate. If there's a
# storage.fullnameOverride field set, then the default pvc will not be
# created, instead the one defined in fullnameOverride will be used
```

However, the current Helm Chart implementation is not using `storage.fullnameOverride` at all. 

Now the chart is using `storage.fullnameOverride` when available and therefore is behaving according to the docs. 