### PR TITLE
Use a fully qualified cluster domain throughout the configuration

### DIFF
--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -154,12 +154,12 @@ function check_creates_template() {
   check_string_existence "--set grpcService.enabled=true --set grpcService.name=weaviate-grpc-service-custom-name" "name: weaviate-grpc-service-custom-name"
 
   _settingPassageQueryOn="--set modules.text2vec-contextionary.enabled=false --set modules.text2vec-transformers.passageQueryServices.passage.enabled=true --set modules.text2vec-transformers.passageQueryServices.query.enabled=true"
-  check_setting_has_value "$_settingPassageQueryOn" "name: TRANSFORMERS_PASSAGE_INFERENCE_API" "value: http://transformers-inference-passage.default.svc.cluster.local:8080"
-  check_setting_has_value "$_settingPassageQueryOn" "name: TRANSFORMERS_QUERY_INFERENCE_API" "value: http://transformers-inference-query.default.svc.cluster.local:8080"
+  check_setting_has_value "$_settingPassageQueryOn" "name: TRANSFORMERS_PASSAGE_INFERENCE_API" "value: http://transformers-inference-passage.default.svc.cluster.local.:8080"
+  check_setting_has_value "$_settingPassageQueryOn" "name: TRANSFORMERS_QUERY_INFERENCE_API" "value: http://transformers-inference-query.default.svc.cluster.local.:8080"
   check_no_setting "$_settingPassageQueryOn" "name: TRANSFORMERS_INFERENCE_API"
 
   _settingPassageQueryOff="--set modules.text2vec-contextionary.enabled=false --set modules.text2vec-transformers.enabled=true"
-  check_setting_has_value "$_settingPassageQueryOff" "name: TRANSFORMERS_INFERENCE_API" "value: http://transformers-inference.default.svc.cluster.local:8080"
+  check_setting_has_value "$_settingPassageQueryOff" "name: TRANSFORMERS_INFERENCE_API" "value: http://transformers-inference.default.svc.cluster.local.:8080"
   check_no_setting "$_settingPassageQueryOff" "name: TRANSFORMERS_PASSAGE_INFERENCE_API"
   check_no_setting "$_settingPassageQueryOff" "name: TRANSFORMERS_QUERY_INFERENCE_API"
 

--- a/weaviate/templates/contextionaryDeployment.yaml
+++ b/weaviate/templates/contextionaryDeployment.yaml
@@ -41,7 +41,7 @@ spec:
           - name: EXTENSIONS_STORAGE_MODE
             value: {{ index $module "envconfig" "extensions_storage_mode" | quote }}
           - name: EXTENSIONS_STORAGE_ORIGIN
-            value: http://{{ .Values.service.name }}.{{ .Release.Namespace }}.svc.cluster.local
+            value: http://{{ .Values.service.name }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
           - name: NEIGHBOR_OCCURRENCE_IGNORE_PERCENTILE
             value: {{ index $module "envconfig" "neighbor_occurrence_ignore_percentile" | quote }}
           - name: ENABLE_COMPOUND_SPLITTING

--- a/weaviate/templates/weaviateConfigMap.yaml
+++ b/weaviate/templates/weaviateConfigMap.yaml
@@ -15,7 +15,7 @@ data:
       {{ toYaml .Values.authorization | nindent 6 | trim }}
     {{ if index .Values "modules" "text2vec-contextionary" "enabled" }}
     contextionary:
-      url: {{ index .Values "modules" "text2vec-contextionary" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:9999
+      url: {{ index .Values "modules" "text2vec-contextionary" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:9999
     {{ end }}
     query_defaults:
       {{ toYaml .Values.query_defaults | nindent 6 | trim }}

--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -99,21 +99,21 @@ spec:
           {{ template "enabled_modules" . }}
           {{- if index .Values "modules" "text2vec-transformers" "enabled" }}
           - name: TRANSFORMERS_INFERENCE_API
-            value: http://{{ index .Values "modules" "text2vec-transformers" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+            value: http://{{ index .Values "modules" "text2vec-transformers" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
           {{- else if index .Values "modules" "text2vec-transformers" "inferenceUrl" }}
           - name: TRANSFORMERS_INFERENCE_API
             value: {{ index .Values "modules" "text2vec-transformers" "inferenceUrl" }}
           {{- else }}
               {{- if index .Values "modules" "text2vec-transformers" "passageQueryServices" "passage" "enabled" }}
           - name: TRANSFORMERS_PASSAGE_INFERENCE_API
-            value: http://{{ index .Values "modules" "text2vec-transformers" "passageQueryServices" "passage" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+            value: http://{{ index .Values "modules" "text2vec-transformers" "passageQueryServices" "passage" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
               {{- else if index .Values "modules" "text2vec-transformers" "passageQueryServices" "passage" "inferenceUrl" }}
           - name: TRANSFORMERS_PASSAGE_INFERENCE_API
             value: {{ index .Values "modules" "text2vec-transformers" "passageQueryServices" "passage" "inferenceUrl" }}
               {{- end }}
               {{- if index .Values "modules" "text2vec-transformers" "passageQueryServices" "query" "enabled" }}
           - name: TRANSFORMERS_QUERY_INFERENCE_API
-            value: http://{{ index .Values "modules" "text2vec-transformers" "passageQueryServices" "query" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+            value: http://{{ index .Values "modules" "text2vec-transformers" "passageQueryServices" "query" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
               {{- else if index .Values "modules" "text2vec-transformers" "passageQueryServices" "query" "inferenceUrl" }}
           - name: TRANSFORMERS_QUERY_INFERENCE_API
             value: {{ index .Values "modules" "text2vec-transformers" "passageQueryServices" "query" "inferenceUrl" }}
@@ -121,63 +121,63 @@ spec:
           {{- end }}
           {{- if index .Values "modules" "text2vec-gpt4all" "enabled" }}
           - name: GPT4ALL_INFERENCE_API
-            value: http://{{ index .Values "modules" "text2vec-gpt4all" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+            value: http://{{ index .Values "modules" "text2vec-gpt4all" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
           {{- else if index .Values "modules" "text2vec-gpt4all" "inferenceUrl" }}
           - name: GPT4ALL_INFERENCE_API
             value: {{ index .Values "modules" "text2vec-gpt4all" "inferenceUrl" }}
           {{- end }}
           {{- if index .Values "modules" "multi2vec-clip" "enabled" }}
           - name: CLIP_INFERENCE_API
-            value: http://{{ index .Values "modules" "multi2vec-clip" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+            value: http://{{ index .Values "modules" "multi2vec-clip" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
           {{- else if index .Values "modules" "multi2vec-clip" "inferenceUrl" }}
           - name: CLIP_INFERENCE_API
             value: {{ index .Values "modules" "multi2vec-clip" "inferenceUrl" }}
           {{- end }}
           {{- if index .Values "modules" "multi2vec-bind" "enabled" }}
           - name: BIND_INFERENCE_API
-            value: http://{{ index .Values "modules" "multi2vec-bind" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+            value: http://{{ index .Values "modules" "multi2vec-bind" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
           {{- else if index .Values "modules" "multi2vec-bind" "inferenceUrl" }}
           - name: BIND_INFERENCE_API
             value: {{ index .Values "modules" "multi2vec-bind" "inferenceUrl" }}
           {{- end }}
           {{- if index .Values "modules" "qna-transformers" "enabled" }}
           - name: QNA_INFERENCE_API
-            value: http://{{ index .Values "modules" "qna-transformers" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+            value: http://{{ index .Values "modules" "qna-transformers" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
           {{- else if index .Values "modules" "qna-transformers" "inferenceUrl" }}
           - name: QNA_INFERENCE_API
             value: {{ index .Values "modules" "qna-transformers" "inferenceUrl" }}
           {{- end }}
           {{- if index .Values "modules" "img2vec-neural" "enabled" }}
           - name: IMAGE_INFERENCE_API
-            value: http://{{ index .Values "modules" "img2vec-neural" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+            value: http://{{ index .Values "modules" "img2vec-neural" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
           {{- else if index .Values "modules" "img2vec-neural" "inferenceUrl" }}
           - name: IMAGE_INFERENCE_API
             value: {{ index .Values "modules" "img2vec-neural" "inferenceUrl" }}
           {{- end }}
           {{- if index .Values "modules" "text-spellcheck" "enabled" }}
           - name: SPELLCHECK_INFERENCE_API
-            value: http://{{ index .Values "modules" "text-spellcheck" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+            value: http://{{ index .Values "modules" "text-spellcheck" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
           {{- else if index .Values "modules" "text-spellcheck" "inferenceUrl" }}
           - name: SPELLCHECK_INFERENCE_API
             value: {{ index .Values "modules" "text-spellcheck" "inferenceUrl" }}
           {{- end }}
           {{- if index .Values "modules" "ner-transformers" "enabled" }}
           - name: NER_INFERENCE_API
-            value: http://{{ index .Values "modules" "ner-transformers" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+            value: http://{{ index .Values "modules" "ner-transformers" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
           {{- else if index .Values "modules" "ner-transformers" "inferenceUrl" }}
           - name: NER_INFERENCE_API
             value: {{ index .Values "modules" "ner-transformers" "inferenceUrl" }}
           {{- end }}
           {{- if index .Values "modules" "sum-transformers" "enabled" }}
           - name: SUM_INFERENCE_API
-            value: http://{{ index .Values "modules" "sum-transformers" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+            value: http://{{ index .Values "modules" "sum-transformers" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
           {{- else if index .Values "modules" "sum-transformers" "inferenceUrl" }}
           - name: SUM_INFERENCE_API
             value: {{ index .Values "modules" "sum-transformers" "inferenceUrl" }}
           {{- end }}
           {{- if index .Values "modules" "reranker-transformers" "enabled" }}
           - name: RERANKER_INFERENCE_API
-            value: http://{{ index .Values "modules" "reranker-transformers" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.cluster.local:8080
+            value: http://{{ index .Values "modules" "reranker-transformers" "fullnameOverride" }}.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}:8080
           {{- else if index .Values "modules" "reranker-transformers" "inferenceUrl" }}
           - name: RERANKER_INFERENCE_API
             value: {{ index .Values "modules" "reranker-transformers" "inferenceUrl" }}
@@ -314,7 +314,7 @@ spec:
             {{- end }}
           {{- end  }}
           - name: CLUSTER_JOIN
-            value: {{ .Values.service.name }}-headless.{{ .Release.Namespace }}.svc.cluster.local
+            value: {{ .Values.service.name }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
         ports:
           - containerPort: 8080
           {{- if .Values.env.PROMETHEUS_MONITORING_ENABLED }}

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -83,6 +83,13 @@ securityContext: {}
 # By default, use the default ServiceAccount
 serviceAccountName:
 
+# Kubernetes Cluster domain name, used for resolving intra-cluster requests, i.e
+# between instances of weaviate.
+# Note: The final '.' on the end of the hostname makes it a FQDN, and is required for
+# DNS to resolve in all kubernetes environments. 
+# See https://github.com/weaviate/weaviate-helm/issues/175 for details.
+clusterDomain: cluster.local.
+
 # The Persistent Volume Claim settings for Weaviate. If there's a
 # storage.fullnameOverride field set, then the default pvc will not be
 # created, instead the one defined in fullnameOverride will be used


### PR DESCRIPTION
Closes #175 - Please see the issue for the exact details on the issue this is fixing.

This PR changes two things:
1. It changes the default `CLUSTER_JOIN` (and other k8s-internal hostnames) to be fully qualified domain names. The difference from the existing configuration is the addition of an additional `.` at the end of the hostnames used (i.e `svc.cluster.local` becomes `svc.cluster.local.`
2. It abstracts the actual value of the internal cluster domain to a value in the helm chart, so that users can configure it to whatever they need. 
    - This is common practice in many helm charts, see examples from bitnami charts [here](https://github.com/bitnami/charts/blob/main/bitnami/milvus/values.yaml#L43) and [here](https://github.com/bitnami/charts/blob/main/bitnami/cassandra/values.yaml#L43)