### PR TITLE
fix: fix the "app.kubernetes.io/managed-by" label

### DIFF
--- a/weaviate/templates/apiKeyCohereSecret.yaml
+++ b/weaviate/templates/apiKeyCohereSecret.yaml
@@ -25,7 +25,7 @@ metadata:
   name: weaviate-cohere
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   {{- if (index .Values "modules" "generative-cohere" "apiKey") }}

--- a/weaviate/templates/apiKeyHuggingFaceSecret.yaml
+++ b/weaviate/templates/apiKeyHuggingFaceSecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: weaviate-huggingface
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   apiKey: {{ index .Values "modules" "text2vec-huggingface" "apiKey" | b64enc }}

--- a/weaviate/templates/apiKeyJinaAISecret.yaml
+++ b/weaviate/templates/apiKeyJinaAISecret.yaml
@@ -5,7 +5,7 @@ metadata:
   name: weaviate-jinaai
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   apiKey: {{ index .Values "modules" "text2vec-jinaai" "apiKey" | b64enc }}

--- a/weaviate/templates/apiKeyOpenAISecret.yaml
+++ b/weaviate/templates/apiKeyOpenAISecret.yaml
@@ -43,7 +43,7 @@ metadata:
   name: weaviate-openai
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   {{- if (index .Values "modules" "qna-openai" "apiKey") }}

--- a/weaviate/templates/apiKeyPaLMSecret.yaml
+++ b/weaviate/templates/apiKeyPaLMSecret.yaml
@@ -21,7 +21,7 @@ metadata:
   name: weaviate-palm
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   {{- if (index .Values "modules" "generative-palm" "apiKey") }}

--- a/weaviate/templates/awsSecret.yaml
+++ b/weaviate/templates/awsSecret.yaml
@@ -25,7 +25,7 @@ metadata:
   name: weaviate-aws
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   {{- if index .Values "modules" "text2vec-aws" "secrets" "AWS_ACCESS_KEY_ID" }}

--- a/weaviate/templates/backupAzureSecret.yaml
+++ b/weaviate/templates/backupAzureSecret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: backup-azure
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   {{- if index $backup "secrets" "AZURE_STORAGE_ACCOUNT" }}

--- a/weaviate/templates/backupGcsSecret.yaml
+++ b/weaviate/templates/backupGcsSecret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: backup-gcs
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   GOOGLE_APPLICATION_CREDENTIALS: {{ index $backup "secrets" "GOOGLE_APPLICATION_CREDENTIALS" | b64enc }}

--- a/weaviate/templates/backupS3Secret.yaml
+++ b/weaviate/templates/backupS3Secret.yaml
@@ -7,7 +7,7 @@ metadata:
   name: backup-s3
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 type: Opaque
 data:
   {{- if index $backup "secrets" "AWS_ACCESS_KEY_ID" }}

--- a/weaviate/templates/contextionaryDeployment.yaml
+++ b/weaviate/templates/contextionaryDeployment.yaml
@@ -8,7 +8,7 @@ metadata:
     name: {{ index $module "fullnameOverride" }}
     app: {{ index $module "fullnameOverride" }}
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ index $module "replicas" }}
   strategy:
@@ -21,7 +21,7 @@ spec:
       labels:
         app: {{ index $module "fullnameOverride" }}
         app.kubernetes.io/name: weaviate
-        app.kubernetes.io/managed-by: helm
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
     spec:
       securityContext:
 {{ toYaml (index $module "securityContext") | indent 8}}
@@ -79,7 +79,7 @@ metadata:
   name: {{ index $module "fullnameOverride" }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: ClusterIP
   selector:

--- a/weaviate/templates/gpt4allInferenceDeployment.yaml
+++ b/weaviate/templates/gpt4allInferenceDeployment.yaml
@@ -8,7 +8,7 @@ metadata:
     name: {{ index $module "fullnameOverride" }}
     app: {{ index $module "fullnameOverride" }}
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ index $module "replicas" }}
   strategy:
@@ -68,7 +68,7 @@ metadata:
   name: {{ index $module "fullnameOverride" }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: ClusterIP
   selector:

--- a/weaviate/templates/img2vecNeuralDeployment.yaml
+++ b/weaviate/templates/img2vecNeuralDeployment.yaml
@@ -8,7 +8,7 @@ metadata:
     name: {{ index $module "fullnameOverride" }}
     app: {{ index $module "fullnameOverride" }}
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ index $module "replicas" }}
   strategy:
@@ -79,7 +79,7 @@ metadata:
   name: {{ index $module "fullnameOverride" }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: ClusterIP
   selector:

--- a/weaviate/templates/multi2vecBindDeployment.yaml
+++ b/weaviate/templates/multi2vecBindDeployment.yaml
@@ -8,7 +8,7 @@ metadata:
     name: {{ index $module "fullnameOverride" }}
     app: {{ index $module "fullnameOverride" }}
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ index $module "replicas" }}
   strategy:
@@ -79,7 +79,7 @@ metadata:
   name: {{ index $module "fullnameOverride" }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: ClusterIP
   selector:

--- a/weaviate/templates/multi2vecClipDeployment.yaml
+++ b/weaviate/templates/multi2vecClipDeployment.yaml
@@ -8,7 +8,7 @@ metadata:
     name: {{ index $module "fullnameOverride" }}
     app: {{ index $module "fullnameOverride" }}
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ index $module "replicas" }}
   strategy:
@@ -79,7 +79,7 @@ metadata:
   name: {{ index $module "fullnameOverride" }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: ClusterIP
   selector:

--- a/weaviate/templates/nerTransformersDeployment.yaml
+++ b/weaviate/templates/nerTransformersDeployment.yaml
@@ -8,7 +8,7 @@ metadata:
     name: {{ index $module "fullnameOverride" }}
     app: {{ index $module "fullnameOverride" }}
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ index $module "replicas" }}
   strategy:
@@ -79,7 +79,7 @@ metadata:
   name: {{ index $module "fullnameOverride" }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: ClusterIP
   selector:

--- a/weaviate/templates/qnaTransformersDeployment.yaml
+++ b/weaviate/templates/qnaTransformersDeployment.yaml
@@ -8,7 +8,7 @@ metadata:
     name: {{ index $module "fullnameOverride" }}
     app: {{ index $module "fullnameOverride" }}
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ index $module "replicas" }}
   strategy:
@@ -79,7 +79,7 @@ metadata:
   name: {{ index $module "fullnameOverride" }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: ClusterIP
   selector:

--- a/weaviate/templates/rerankerTransformersDeployment.yaml
+++ b/weaviate/templates/rerankerTransformersDeployment.yaml
@@ -8,7 +8,7 @@ metadata:
     name: {{ index $module "fullnameOverride" }}
     app: {{ index $module "fullnameOverride" }}
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ index $module "replicas" }}
   strategy:
@@ -79,7 +79,7 @@ metadata:
   name: {{ index $module "fullnameOverride" }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: ClusterIP
   selector:

--- a/weaviate/templates/sumTransformersDeployment.yaml
+++ b/weaviate/templates/sumTransformersDeployment.yaml
@@ -8,7 +8,7 @@ metadata:
     name: {{ index $module "fullnameOverride" }}
     app: {{ index $module "fullnameOverride" }}
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ index $module "replicas" }}
   strategy:
@@ -79,7 +79,7 @@ metadata:
   name: {{ index $module "fullnameOverride" }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: ClusterIP
   selector:

--- a/weaviate/templates/textSpellcheckDeployment.yaml
+++ b/weaviate/templates/textSpellcheckDeployment.yaml
@@ -8,7 +8,7 @@ metadata:
     name: {{ index $module "fullnameOverride" }}
     app: {{ index $module "fullnameOverride" }}
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ index $module "replicas" }}
   strategy:
@@ -68,7 +68,7 @@ metadata:
   name: {{ index $module "fullnameOverride" }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 spec:
   type: ClusterIP

--- a/weaviate/templates/transformersInferenceDeployment.yaml
+++ b/weaviate/templates/transformersInferenceDeployment.yaml
@@ -10,7 +10,7 @@ metadata:
     name: {{ index $module "fullnameOverride" }}
     app: {{ index $module "fullnameOverride" }}
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ index $module "replicas" }}
   strategy:
@@ -89,7 +89,7 @@ metadata:
   name: {{ index $module "fullnameOverride" }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: ClusterIP
   selector:

--- a/weaviate/templates/weaviateConfigMap.yaml
+++ b/weaviate/templates/weaviateConfigMap.yaml
@@ -5,7 +5,7 @@ metadata:
   name: weaviate-config
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 data:
   conf.yaml: |-
     ---

--- a/weaviate/templates/weaviateHeadlessService.yaml
+++ b/weaviate/templates/weaviateHeadlessService.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.service.name }}-headless
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   type: ClusterIP
   clusterIP: None

--- a/weaviate/templates/weaviateService.yaml
+++ b/weaviate/templates/weaviateService.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ .Values.service.name }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{- with .Values.service.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/weaviate/templates/weaviateServiceGRPC.yaml
+++ b/weaviate/templates/weaviateServiceGRPC.yaml
@@ -5,7 +5,7 @@ metadata:
   name: {{ .Values.grpcService.name }}
   labels:
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
   {{- with .Values.grpcService.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/weaviate/templates/weaviateServiceMonitor.yaml
+++ b/weaviate/templates/weaviateServiceMonitor.yaml
@@ -7,13 +7,13 @@ metadata:
     name: weaviate
     app: weaviate
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   jobLabel: weaviate
   selector:
     matchLabels:
       app.kubernetes.io/name: weaviate
-      app.kubernetes.io/managed-by: helm
+      app.kubernetes.io/managed-by: {{ .Release.Service }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}

--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -6,7 +6,7 @@ metadata:
     name: weaviate
     app: weaviate
     app.kubernetes.io/name: weaviate
-    app.kubernetes.io/managed-by: helm
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicas }}
   updateStrategy:
@@ -20,7 +20,7 @@ spec:
       labels:
         app: weaviate
         app.kubernetes.io/name: weaviate
-        app.kubernetes.io/managed-by: helm
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
       annotations:
         # To restart Pods if the ConfigMap is updated.
         checksum/config: {{ include (print $.Template.BasePath "/weaviateConfigMap.yaml") . | sha256sum }}
@@ -447,7 +447,7 @@ spec:
       name: weaviate-data
       labels:
         app.kubernetes.io/name: weaviate
-        app.kubernetes.io/managed-by: helm
+        app.kubernetes.io/managed-by: {{ .Release.Service }}
     spec:
       accessModes: [ "ReadWriteOnce" ]
       storageClassName: {{ .Values.storage.storageClassName }}


### PR DESCRIPTION
* Previously, it was hard coded to be `helm`
* But on GKE, this changes to `Helm` with capital `H`
* This causes a mismatch between the `Service` and the `ServiceMonitor`
* Because the components labels changes to `Helm`
* But, the ServiceMonitor `spec.selector.matchLabels` remains `helm` with lowercase `h`
* So, to avoid this, I think it's better to set them all to `{{ .Release.Service }} instead
* refer to #192 