### PR TITLE
Add support for configuring hostAliases of Weaviate pod

### DIFF
--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -448,6 +448,10 @@ spec:
       tolerations:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
 
   volumeClaimTemplates:
   - metadata:

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -1546,6 +1546,8 @@ nodeSelector:
 
 tolerations:
 
+hostAliases:
+
 affinity:
   podAntiAffinity:
     preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
`hostAliases` allows you to perform hostname resolution when DNS is not available (see https://kubernetes.io/docs/tasks/network/customize-hosts-file-for-pods/). In my case, this is required to reach an Azure OpenAI deployment via a private endpoint (DNS not available, and correct hostname still has to be used so that certificate validation can succeed).

Previously, it was not possible to configure this setting when using the Weaviate helm chart, this PR allows the user to add a configuration of the `hostAliases` used for the Weaviate pod.

Note that this PR does not add this setting to other pods than the Weaviate pod. For my current use case, that is sufficient, but maybe it still would be desirable to have it applied also to other pods (maybe same behaviour as `nodeSelector`/`tolerations`/`affinity` with a global + module level config).