### PR TITLE
Make securityContext configurable for weaviate container

### DIFF
--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -195,6 +195,7 @@ function check_creates_template() {
   check_string_existence "--set extraVolumeMounts[0].name=test-extra-volumemount" "name: test-extra-volumemount"
 
   check_string_existence "--set securityContext.thisIsATest=true " "thisIsATest: true"
+  check_string_existence "--set containerSecurityContext.allowPrivilegeEscalation=false " "allowPrivilegeEscalation: false"
   check_string_existence "" "imagePullPolicy: IfNotPresent"
   check_setting_has_value "--set image.pullSecrets[0]=weaviate-image-pull-secret" "imagePullSecrets" "name: weaviate-image-pull-secret"
   check_setting_has_value "--set updateStrategy.type=OnDelete" "updateStrategy" "type: OnDelete"

--- a/weaviate/Chart.yaml
+++ b/weaviate/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 16.8.1
+version: 16.8.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -411,6 +411,8 @@ spec:
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           successThreshold: {{ .Values.readinessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+        securityContext:
+{{ toYaml .Values.containerSecurityContext | indent 10}}
       volumes:
         - name: weaviate-config
           configMap:

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -76,6 +76,9 @@ resources: {}
 # as described here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
 securityContext: {}
 
+# Security context for the Weaviate container. Override overlapping settings made at the Pod level.
+containerSecurityContext: {}
+
 
 # Add a service account ot the Weaviate pods if you need Weaviate to have permissions to
 # access kubernetes resources or cloud provider resources. For example for it to have


### PR DESCRIPTION
Currently, it is only possible to set [PodSecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#podsecuritycontext-v1-core) for Weaviate StatefulSet, but it's not possible to set security context for the main `weaviate` container, which is backed by [SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.29/#securitycontext-v1-core) object and contains additional configuration parameters extending the `PodSecurityContext`, allowing fine-granular overwrites on the container level.
This PR:
- introduces a new value `containerSecurityContext` in `values.yaml`
- propagates the value to the `securityContext` of the `weaviate` container
- adds a test to verify new field
- bumps chart version to `16.8.2`