### PR TITLE
Change gRPC service type to LoadBalancer and enable it by default

### DIFF
--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -165,6 +165,7 @@ function check_creates_template() {
   check_string_existence "--set modules.text2vec-jinaai.enabled=true --set modules.text2vec-jinaai.apiKey=jinaaiApiKey" "name: JINAAI_APIKEY"
   check_string_existence "--set grpcService.enabled=true" "containerPort: 50051"
   check_string_existence "--set grpcService.enabled=true --set grpcService.name=weaviate-grpc-service-custom-name" "name: weaviate-grpc-service-custom-name"
+  check_string_existence "--set grpcService.name=weaviate-grpc-defult-service-custom-name" "name: weaviate-grpc-defult-service-custom-name"
   check_string_existence "--set modules.text2vec-aws.enabled=true --set modules.text2vec-aws.secrets.AWS_ACCESS_KEY_ID=key --set modules.text2vec-aws.secrets.AWS_SECRET_ACCESS_KEY=secret" "name: AWS_ACCESS_KEY_ID"
   check_string_existence "--set modules.text2vec-aws.enabled=true --set modules.text2vec-aws.secrets.AWS_ACCESS_KEY_ID=key --set modules.text2vec-aws.secrets.AWS_SECRET_ACCESS_KEY=secret" "name: AWS_SECRET_ACCESS_KEY"
   check_string_existence "--set modules.generative-aws.enabled=true --set modules.generative-aws.secrets.AWS_ACCESS_KEY_ID=key --set modules.generative-aws.secrets.AWS_SECRET_ACCESS_KEY=secret" "name: AWS_ACCESS_KEY_ID"

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -7,7 +7,7 @@ image:
   # of weaviate. In accordance with Infra-as-code, you should pin this value
   # down and only change it if you explicitly want to upgrade the Weaviate
   # version.
-  tag: 1.24.8
+  tag: 1.24.9
   repo: semitechnologies/weaviate
   # Image pull policy: https://kubernetes.io/docs/concepts/containers/images/#image-pull-policy
   pullPolicy: IfNotPresent
@@ -117,18 +117,19 @@ service:
   annotations: {}
 
 # The service controls how weaviate gRPC endpoint is exposed to the outside world.
-# If you don't want a public load balancer, you can also choose 'ClusterIP' to make
-# weaviate gRPC port be only accessible within your cluster.
+# If you don't want a public load balancer, you can also choose 'ClusterIP' or `NodePort`
+# to make weaviate gRPC port be only accessible within your cluster.
+# This service is by default enabled but if you don't want it to be deployed in your
+# environment then it can be disabled by setting enabled: false option.
 grpcService:
-  # Set this to true in order to deploy Weaviate gRPC service
-  enabled: false
+  enabled: true
   name: weaviate-grpc
   ports:
     - name: grpc
       protocol: TCP
       port: 50051
       # Target port is going to be the same for every port
-  type: NodePort
+  type: LoadBalancer
   loadBalancerSourceRanges: []
   # optionally set cluster IP if you want to set a static IP
   clusterIP:


### PR DESCRIPTION
This PR enables gRPC service by default and changes it's type to `LoadBalancer`.