### PR TITLE
Add ability to configure probe types and probes

### DIFF
--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -255,5 +255,9 @@ function check_creates_template() {
   check_no_setting "--set env.PROMETHEUS_MONITORING_ENABLED=false --set serviceMonitor.enabled=true" "kind: ServiceMonitor"
   check_no_setting "--set env.PROMETHEUS_MONITORING_ENABLED=false --set serviceMonitor.enabled=false" "kind: ServiceMonitor"
 
+  check_string_existence "--set readinessProbe.probeType=exec --set readinessProbe.probe.exec.command={test-probe-cmd}" "exec:"
+  check_string_existence "--set readinessProbe.probeType=exec --set readinessProbe.probe.exec.command={test-probe-cmd}" "command:"
+  check_string_existence "--set readinessProbe.probeType=exec --set readinessProbe.probe.exec.command={test-probe-cmd}" "test-probe-cmd"
+  
   echo "Tests successful."
 )

--- a/weaviate/Chart.yaml
+++ b/weaviate/Chart.yaml
@@ -7,7 +7,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 16.8.8
+version: 16.8.9
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -398,9 +398,10 @@ spec:
           {{- end }}
         {{- if .Values.startupProbe.enabled }}
         startupProbe:
-          httpGet:
-            path: /v1/.well-known/ready
-            port: 8080
+          {{- $probeType := .Values.startupProbe.probeType }}
+          {{- $probe := index .Values.startupProbe.probe $probeType }}
+          {{ $probeType }}:
+            {{- toYaml $probe | nindent 12 }}
           initialDelaySeconds: {{ .Values.startupProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.startupProbe.periodSeconds }}
           failureThreshold: {{ .Values.startupProbe.failureThreshold }}
@@ -408,18 +409,20 @@ spec:
           timeoutSeconds: {{ .Values.startupProbe.timeoutSeconds }}
         {{- end }}
         livenessProbe:
-          httpGet:
-            path: /v1/.well-known/live
-            port: 8080
+          {{- $probeType := .Values.livenessProbe.probeType }}
+          {{- $probe := index .Values.livenessProbe.probe $probeType }}
+          {{ $probeType }}:
+            {{- toYaml $probe | nindent 12 }}
           initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
           failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           successThreshold: {{ .Values.livenessProbe.successThreshold }}
           timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
         readinessProbe:
-          httpGet:
-            path: /v1/.well-known/ready
-            port: 8080
+          {{- $probeType := .Values.readinessProbe.probeType }}
+          {{- $probe := index .Values.readinessProbe.probe $probeType }}
+          {{ $probeType }}:
+            {{- toYaml $probe | nindent 12 }}
           initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
           periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
           failureThreshold: {{ .Values.readinessProbe.failureThreshold }}

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -146,7 +146,11 @@ serviceMonitor:
 startupProbe:
   # For kubernetes versions prior to 1.18 startupProbe is not supported thus can be disabled.
   enabled: false
-
+  probeType: httpGet
+  probe:
+    httpGet:
+      path: /v1/.well-known/ready
+      port: 8080
   initialDelaySeconds: 300
   periodSeconds: 60
   failureThreshold: 50
@@ -154,6 +158,11 @@ startupProbe:
   timeoutSeconds: 3
 
 livenessProbe:
+  probeType: httpGet
+  probe:
+    httpGet:
+      path: /v1/.well-known/live
+      port: 8080
   initialDelaySeconds: 900
   periodSeconds: 10
   failureThreshold: 30
@@ -161,6 +170,11 @@ livenessProbe:
   timeoutSeconds: 3
 
 readinessProbe:
+  probeType: httpGet
+  probe:
+    httpGet:
+      path: /v1/.well-known/ready
+      port: 8080
   initialDelaySeconds: 3
   periodSeconds: 10
   failureThreshold: 3

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -143,6 +143,13 @@ serviceMonitor:
   scrapeTimeout: 10s
 
 # Adjust liveness, readiness and startup probes configuration
+# below is an example that can be used to switch the probeType to exec command
+# readinessProbe: # (Compatible with liveness, readiness and startup probe configurations)
+#   probeType: exec
+#   probe:
+#     exec:
+#       command: ["/bin/sh", "-c", "wget --spider --server-response --tries=1 --timeout=30 -o /dev/null localhost:8080/v1/.well-known/ready"]
+
 startupProbe:
   # For kubernetes versions prior to 1.18 startupProbe is not supported thus can be disabled.
   enabled: false


### PR DESCRIPTION
Add ability to configure probe types and probes. This is particularly useful in mTLS scenarios where an exec command probe is desired.

Usage:

```yaml
  startupProbe:
    enabled: true
    probeType: exec
    probe:
      exec:
        command: ["/bin/sh", "-c", "wget --spider --server-response --tries=1 --timeout=30 -o /dev/null localhost:8080/v1/.well-known/ready"]
  livenessProbe:
    probeType: exec
    probe:
      exec:
        command: ["/bin/sh", "-c", "wget --spider --server-response --tries=1 --timeout=30 -o /dev/null localhost:8080/v1/.well-known/live"]
  readinessProbe:
    probeType: exec
    probe:
      exec:
        command: ["/bin/sh", "-c", "wget --spider --server-response --tries=1 --timeout=30 -o /dev/null localhost:8080/v1/.well-known/ready"]
```