### PR TITLE
Add loadBalancerIp configuration for HTTP and GPRS services

### DIFF
--- a/weaviate/templates/weaviateService.yaml
+++ b/weaviate/templates/weaviateService.yaml
@@ -23,6 +23,9 @@ spec:
   {{ end }}
 {{ end }}
 {{ if eq .Values.service.type "LoadBalancer" -}}
+  {{ if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{ end }}
   {{- if gt (len .Values.service.loadBalancerSourceRanges) 0 }}
   loadBalancerSourceRanges:
     {{- range $_, $sourceRange := .Values.service.loadBalancerSourceRanges }}

--- a/weaviate/templates/weaviateServiceGRPC.yaml
+++ b/weaviate/templates/weaviateServiceGRPC.yaml
@@ -24,6 +24,9 @@ spec:
   {{ end }}
 {{ end }}
 {{ if eq .Values.grpcService.type "LoadBalancer" -}}
+  {{ if .Values.service.loadBalancerIP }}
+  loadBalancerIP: {{ .Values.service.loadBalancerIP }}
+  {{ end }}
   {{- if gt (len .Values.grpcService.loadBalancerSourceRanges) 0 }}
   loadBalancerSourceRanges:
     {{- range $_, $sourceRange := .Values.grpcService.loadBalancerSourceRanges }}


### PR DESCRIPTION
I needed to set this value when using services of the type LoadBalancer. The value is not available right now.