### PR TITLE
Delete unused environment variable STANDALONE_MODE

### DIFF
--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -106,8 +106,6 @@ spec:
               secretKeyRef:
                 name: weaviate-cluster-api-basic-auth
                 key: password
-          - name: STANDALONE_MODE
-            value: 'true'
           - name: PERSISTENCE_DATA_PATH
             value: '/var/lib/weaviate'
           - name: DEFAULT_VECTORIZER_MODULE


### PR DESCRIPTION
STANDALONE_MODE was an experimental setting in Weaviate 0.x, the environment variable is not used anymore in the current code base. Fixes #229.