### PR TITLE
Add label to weaviate service for monitoring.

### DIFF
--- a/weaviate/templates/weaviateService.yaml
+++ b/weaviate/templates/weaviateService.yaml
@@ -5,6 +5,9 @@ metadata:
   labels:
     app.kubernetes.io/name: weaviate
     app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- if and .Values.env.PROMETHEUS_MONITORING_ENABLED .Values.serviceMonitor.enabled }}
+    monitoring: enabled
+{{- end }}
   {{- with .Values.service.annotations }}
   annotations: {{ toYaml . | nindent 4 }}
   {{- end }}

--- a/weaviate/templates/weaviateServiceMonitor.yaml
+++ b/weaviate/templates/weaviateServiceMonitor.yaml
@@ -14,6 +14,7 @@ spec:
     matchLabels:
       app.kubernetes.io/name: weaviate
       app.kubernetes.io/managed-by: {{ .Release.Service }}
+      monitoring: enabled
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace | quote }}

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -162,6 +162,8 @@ grpcService:
 
 # The service monitor defines prometheus monitoring for a set of services
 # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor
+# Make sure to set the following prometheus values if deploying observability with the kube-prometheus-stack helm chart:
+# - prometheus.prometheusSpec.serviceMonitorSelectorNilUsesHelmValues: false
 serviceMonitor:
   enabled: false
   interval: 30s


### PR DESCRIPTION
Currently, the ServiceMonitor uses a set of labels which match all the three existing services: weaviate, weaviate-headless and weaviate-grpc. This ends up into importing three different targets in Prometheus, multiplying all the metrics by 3. This PR adds a new label monitoring: enabled in the weaviate service only if serviceMonitor is enabled (and the PROMETHEUS env variable too). Like this, only one target will be imported, reducing the number of metrics.