### PR TITLE
Clarify When to Use a Persistent Volume

### DIFF
--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -119,7 +119,7 @@ serviceAccountName:
 clusterDomain: cluster.local.
 
 # The Persistent Volume Claim settings for Weaviate. If there's a
-# storage.fullnameOverride field set, then the default pvc will not be
+# storage.fullnameOverride field set, then the default pv will not be
 # created, instead the one defined in fullnameOverride will be used
 storage:
   size: 32Gi


### PR DESCRIPTION
I changed the reference from Persistent Volume Claim (PVC) to Persistent Volume (PV) in the `storage.fullnameOverride` field of the helm file. This instructs the user on when they should specify a PV.

I agree to the CLA.