### PR TITLE
expose metadata service port on weaviate core nodes

### DIFF
--- a/weaviate/templates/querierDeployment.yaml
+++ b/weaviate/templates/querierDeployment.yaml
@@ -396,6 +396,11 @@ spec:
             containerPort: 50051
             protocol: TCP
           {{- end }}
+          {{ if .Values.metadataService.enabled }}
+          - name: grpc
+            containerPort: 9050
+            protocol: TCP
+          {{- end }}
         volumeMounts:
           - name: weaviate-config
             mountPath: /weaviate-config

--- a/weaviate/templates/weaviateServiceMetadata.yaml
+++ b/weaviate/templates/weaviateServiceMetadata.yaml
@@ -1,0 +1,34 @@
+{{ if .Values.metadataService.enabled }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ .Values.metadataService.name }}
+  labels:
+    app.kubernetes.io/name: weaviate
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.metadataService.annotations }}
+  annotations: {{ toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  type: {{ .Values.metadataService.type }}
+  selector:
+    app: weaviate
+  ports:
+    {{- range .Values.metadataService.ports }}
+    - {{ toYaml . | indent 6 | trim }}
+      targetPort: 9050
+    {{- end }}
+{{ if eq .Values.metadataService.type "ClusterIP" -}}
+  {{ if .Values.metadataService.clusterIP }}
+  clusterIP: {{ .Values.metadataService.clusterIP }}
+  {{ end }}
+{{ end }}
+{{ if eq .Values.metadataService.type "LoadBalancer" -}}
+  {{- if gt (len .Values.metadataService.loadBalancerSourceRanges) 0 }}
+  loadBalancerSourceRanges:
+    {{- range $_, $sourceRange := .Values.metadataService.loadBalancerSourceRanges }}
+    - {{ $sourceRange }}
+    {{ end -}}
+  {{- end -}}
+{{- end }}
+{{ end }}

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -209,6 +209,21 @@ grpcService:
   clusterIP:
   annotations: {}
 
+# TODO
+metadataService:
+  enabled: false
+  name: weaviate-metadata
+  ports:
+    - name: grpc
+      protocol: TCP
+      port: 9050
+      # Target port is going to be the same for every port
+  type: LoadBalancer
+  loadBalancerSourceRanges: []
+  # optionally set cluster IP if you want to set a static IP
+  clusterIP:
+  annotations: {}
+
 # The service monitor defines prometheus monitoring for a set of services
 # https://github.com/prometheus-operator/prometheus-operator/blob/main/Documentation/api.md#monitoring.coreos.com/v1.ServiceMonitor
 # Make sure to set the following prometheus values if deploying observability with the kube-prometheus-stack helm chart:


### PR DESCRIPTION
Started adding port 9050 as a service on the core metadata nodes so that the querier nodes can connect to the core nodes via that port. Please feel free to push forward on this