### PR TITLE
Document rbac's variables.

### DIFF
--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -25,15 +25,15 @@ args:
   - 'http'
   - '--config-file'
   - '/weaviate-config/conf.yaml'
-  - --read-timeout=60s 
+  - --read-timeout=60s
   - --write-timeout=60s
 
 # below is an example that can be used to set an arbitrary nofile limit at
 # startup:
 #
-# command: 
+# command:
 #   - "/bin/sh"
-# args: 
+# args:
 #   - "-c"
 #   - "ulimit -n 65535 && /bin/weaviate --host 0.0.0.0 --port 8080 --scheme http --config-file /weaviate-config/conf.yaml"
 
@@ -114,7 +114,7 @@ serviceAccountName:
 # Kubernetes Cluster domain name, used for resolving intra-cluster requests, i.e
 # between instances of weaviate.
 # Note: The final '.' on the end of the hostname makes it a FQDN, and is required for
-# DNS to resolve in all kubernetes environments. 
+# DNS to resolve in all kubernetes environments.
 # See https://github.com/weaviate/weaviate-helm/issues/175 for details.
 clusterDomain: cluster.local.
 
@@ -253,6 +253,14 @@ authentication:
     # client_id: ''
 
 authorization:
+  rbac:
+    enabled: false
+    # admins:
+    # - admin_user1
+    # - admin_user2
+    # viewers:
+    # - viewer_user1
+    # - readonly_user1
   admin_list:
     enabled: false
     # users:
@@ -316,7 +324,7 @@ env:
   PROMETHEUS_MONITORING_ENABLED: false
   PROMETHEUS_MONITORING_GROUP: false
 
-  # Set a MEM limit for the Weaviate Pod so it can help you both increase GC-related 
+  # Set a MEM limit for the Weaviate Pod so it can help you both increase GC-related
   # performance as well as avoid GC-related out-of-memory (“OOM”) situations
   # GOMEMLIMIT: 6GiB
 
@@ -337,7 +345,8 @@ env:
   # If using ENV Vars to set up API Keys make sure to have `authentication.apikey` block commented out
   # to avoid any future changes. ENV Vars has priority over the config above `authentication.apikey`.
   # If using `authentication.apikey `the below ENV Vars will be used because they have priority,
-  # so comment them out to avoid any future changes.
+  # so comment them out to avoid any future changes. The same applies for the RBAC configuration
+  # under the authorization block.
   # Enables API key authentication. If it is set to 'false' the AUTHENTICATION_APIKEY_ALLOWED_KEYS
   # and AUTHENTICATION_APIKEY_USERS will not have any effect.
   # AUTHENTICATION_APIKEY_ENABLED: 'true'
@@ -351,6 +360,21 @@ env:
   # NOTE: Make sure to add the users to the authorization above overwise they will not be allowed to interact with Weaviate.
   # AUTHENTICATION_APIKEY_USERS: 'jane@doe.com,ian-smith'
 
+  # Enabling RBAC authorization. It is mutually exclusive with the AUTHORIZATION_ADMIN_LISTS variable. Either RBAC or the
+  # admin lists mechanism can be used.
+  # AUTHORIZATION_ENABLE_RBAC: "true"
+
+  # Users with admin's RBAC role. List one or more user identities, separated by commas, which will
+  # have the admin role assigned to. This role provides all permissions to the user, but it's required at least
+  # in one of the user for managing the cluster.
+  # AUTHORIZATION_ADMIN_USERS: "admin-user"
+
+  # Users with viewer's RBAC role. List one or more user identities, separated by commas, which will
+  # have the viewer role assigned to. This role allows read permissions in all different areas. Once assigned via
+  # config, it can't be revoked via API AuthZ calls.
+  # AUTHORIZATION_VIEWER_USERS: "viewer-user"
+
+
 envSecrets:
   # create a Kubernetes secret with AUTHENTICATION_APIKEY_ALLOWED_KEYS key and its respective value
   # AUTHENTICATION_APIKEY_ALLOWED_KEYS: name-of-the-k8s-secret-containing-the-comma-separated-api-keys
@@ -362,7 +386,7 @@ offload:
     # If one is using AWS EKS and has already configured K8s Service Account
     # that holds the AWS credentials one can pass a name of that service account
     # here using this setting.
-    # NOTE: the root `serviceAccountName` config has priority over this one, and 
+    # NOTE: the root `serviceAccountName` config has priority over this one, and
     # if the root one is set this one will NOT overwrite it. This one is here for
     # backwards compatibility.
     serviceAccountName:
@@ -371,7 +395,7 @@ offload:
       # Configure bucket where data should be saved, this setting is mandatory
       OFFLOAD_S3_BUCKET: weaviate-offload
 
-      # Optional setting. Defaults to AWS S3 (s3.amazonaws.com). 
+      # Optional setting. Defaults to AWS S3 (s3.amazonaws.com).
       # Set this option if you have a MinIO storage configured in your environment
       # and want to use it instead of the AWS S3.
       # OFFLOAD_S3_ENDPOINT: custom.minio.endpoint.address
@@ -384,7 +408,7 @@ offload:
       # Set this option if you wan't Weaviate to create
       # the bucket used for offloading tenants. Otherwise,
       # if set to false Weaviate expects the bucket to be
-      # already created with the OFFLOAD_S3_BUCKET name 
+      # already created with the OFFLOAD_S3_BUCKET name
       # OFFLOAD_S3_BUCKET_AUTO_CREATE: true
 
       # You can pass environment AWS settings here:
@@ -417,13 +441,13 @@ backups:
     envconfig:
       # Configure folder where backups should be saved
       BACKUP_FILESYSTEM_PATH: /tmp/backups
-  
+
   s3:
     enabled: false
     # If one is using AWS EKS and has already configured K8s Service Account
     # that holds the AWS credentials one can pass a name of that service account
     # here using this setting.
-    # NOTE: the root `serviceAccountName` config has priority over this one, and 
+    # NOTE: the root `serviceAccountName` config has priority over this one, and
     # if the root one is set this one will NOT overwrite it. This one is here for
     # backwards compatibility.
     serviceAccountName:
@@ -432,17 +456,17 @@ backups:
       # Configure bucket where backups should be saved, this setting is mandatory
       BACKUP_S3_BUCKET: weaviate-backups
 
-      # Optional setting. Defaults to empty string. 
+      # Optional setting. Defaults to empty string.
       # Set this option if you want to save backups to a given location
       # inside the bucket
       # BACKUP_S3_PATH: path/inside/bucket
 
-      # Optional setting. Defaults to AWS S3 (s3.amazonaws.com). 
+      # Optional setting. Defaults to AWS S3 (s3.amazonaws.com).
       # Set this option if you have a MinIO storage configured in your environment
       # and want to use it instead of the AWS S3.
       # BACKUP_S3_ENDPOINT: custom.minio.endpoint.address
 
-      # Optional setting. Defaults to true. 
+      # Optional setting. Defaults to true.
       # Set this option if you don't want to use SSL.
       # BACKUP_S3_USE_SSL: true
 
@@ -455,7 +479,7 @@ backups:
     # You can pass the User credentials (access-key id and access-secret-key) in 2 ways:
     # 1. by setting the AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY plain values in the `secrets` section below
     #     this chart will create a kubernetes secret for you with these key-values pairs
-    # 2. create Kubernetes secret/s with AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY  keys and their respective values 
+    # 2. create Kubernetes secret/s with AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY  keys and their respective values
     #     Set the Key and the secret where it is set in `envSecrets` section below
     secrets: {}
     #   AWS_ACCESS_KEY_ID: access-key-id (plain text)
@@ -503,7 +527,7 @@ backups:
       # Configure container where backups should be saved, this setting is mandatory
       BACKUP_AZURE_CONTAINER: weaviate-backups
 
-      # Optional setting. Defaults to empty string. 
+      # Optional setting. Defaults to empty string.
       # Set this option if you want to save backups to a given location
       # inside the container
       # BACKUP_AZURE_PATH: path/inside/container
@@ -514,7 +538,7 @@ backups:
     # 1. by setting the AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY
     #     or AZURE_STORAGE_CONNECTION_STRING plain values in the `secrets` section below
     #     this chart will create a kubernetes secret for you with these key-values pairs
-    # 2. create Kubernetes secret/s with AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY 
+    # 2. create Kubernetes secret/s with AZURE_STORAGE_ACCOUNT and AZURE_STORAGE_KEY
     #     or AZURE_STORAGE_CONNECTION_STRING and their respective values
     #     Set the Key and the secret where it is set in `envSecrets` section below
     secrets: {}
@@ -660,7 +684,7 @@ modules:
     # as described here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     # applies to passageQueryService below
     securityContext: {}
-    
+
     # It is possible to add a ServiceAccount to this module's Pods, it can be
     # used in cases where the module is in a private registry and you want to
     # give access to the registry only to this pod.
@@ -728,13 +752,13 @@ modules:
         # as described here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
         # applies to passageQueryService below
         securityContext: {}
-        
+
         # It is possible to add a ServiceAccount to this module's Pods, it can be
         # used in cases where the module is in a private registry and you want to
         # give access to the registry only to this pod.
         # NOTE: if not set the root `serviceAccountName` config will be used.
         serviceAccountName:
-        
+
         # You can guide where the pods are scheduled on a per-module basis,
         # as well as for Weaviate overall. Each module accepts nodeSelector,
         # tolerations, and affinity configuration. If it is set on a per-
@@ -797,7 +821,7 @@ modules:
         # as described here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
         # applies to passageQueryService below
         securityContext: {}
-        
+
         # It is possible to add a ServiceAccount to this module's Pods, it can be
         # used in cases where the module is in a private registry and you want to
         # give access to the registry only to this pod.
@@ -818,7 +842,7 @@ modules:
   # These models run only on CPU only and on x86_64 arch
   # The ML model is containerized in a Weaviate compatible way.
   # If you want to run a different model that published ones you can follow the
-  # tutorial from here on how to create such a container: https://github.com/weaviate/t2v-gpt4all-models 
+  # tutorial from here on how to create such a container: https://github.com/weaviate/t2v-gpt4all-models
   text2vec-gpt4all:
 
     # Enable deployment of this module
@@ -827,7 +851,7 @@ modules:
     # You can set directly an inference URL of this module without deploying it with this release.
     # You can do so by setting a value for the `inferenceUrl` here AND by setting the `enable` to `false`
     inferenceUrl: {}
-    
+
     # The configuration below is ignored if enabled==false
     tag: all-MiniLM-L6-v2
     repo: semitechnologies/gpt4all-inference
@@ -859,7 +883,7 @@ modules:
     # security Context for the Contextionary Pods. The configurations are the same as setting them
     # as described here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     securityContext: {}
-    
+
     # It is possible to add a ServiceAccount to this module's Pods, it can be
     # used in cases where the module is in a private registry and you want to
     # give access to the registry only to this pod.
@@ -1306,7 +1330,7 @@ modules:
     # security Context for the Contextionary Pods. The configurations are the same as setting them
     # as described here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     securityContext: {}
-    
+
     # It is possible to add a ServiceAccount to this module's Pods, it can be
     # used in cases where the module is in a private registry and you want to
     # give access to the registry only to this pod.
@@ -1552,7 +1576,7 @@ modules:
     # security Context for the Contextionary Pods. The configurations are the same as setting them
     # as described here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     securityContext: {}
-    
+
     # It is possible to add a ServiceAccount to this module's Pods, it can be
     # used in cases where the module is in a private registry and you want to
     # give access to the registry only to this pod.
@@ -1569,7 +1593,7 @@ modules:
     affinity:
 
   # The reranker-cohere module uses Cohere API
-  # to dynamically compute a score for the relevance 
+  # to dynamically compute a score for the relevance
   # of the query with each of the initial search results.
   # More information about Cohere API can be found here: https://docs.cohere.com/docs/rerank-guide
   reranker-cohere:
@@ -1582,7 +1606,7 @@ modules:
     apiKey: ''
 
   # The reranker-voyageai module uses VoaygeAI API
-  # to dynamically compute a score for the relevance 
+  # to dynamically compute a score for the relevance
   # of the query with each of the initial search results.
   # More information about Cohere API can be found here: https://www.voyageai.com/
   reranker-voyageai:
@@ -1595,7 +1619,7 @@ modules:
     apiKey: ''
 
   # The reranker-jinaai module uses JinaAI API
-  # to dynamically compute a score for the relevance 
+  # to dynamically compute a score for the relevance
   # of the query with each of the initial search results.
   # More information about Cohere API can be found here: https://jina.ai/reranker
   reranker-jinaai:
@@ -1607,7 +1631,7 @@ modules:
     # an environment variable
     apiKey: ''
 
-  # The reranker-transformers module uses Cross-Encoders for 
+  # The reranker-transformers module uses Cross-Encoders for
   # sentence pair scoring and sentence pair classification tasks.
   # More information about Cross-Encoders can be found here:
   # https://www.sbert.net/examples/applications/cross-encoder/README.html
@@ -1665,7 +1689,7 @@ modules:
     # security Context for the Contextionary Pods. The configurations are the same as setting them
     # as described here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     securityContext: {}
-    
+
     # It is possible to add a ServiceAccount to this module's Pods, it can be
     # used in cases where the module is in a private registry and you want to
     # give access to the registry only to this pod.
@@ -1722,7 +1746,7 @@ modules:
     # security Context for the Contextionary Pods. The configurations are the same as setting them
     # as described here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     securityContext: {}
-    
+
     # It is possible to add a ServiceAccount to this module's Pods, it can be
     # used in cases where the module is in a private registry and you want to
     # give access to the registry only to this pod.
@@ -1796,7 +1820,7 @@ modules:
     # security Context for the Contextionary Pods. The configurations are the same as setting them
     # as described here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     securityContext: {}
-    
+
     # It is possible to add a ServiceAccount to this module's Pods, it can be
     # used in cases where the module is in a private registry and you want to
     # give access to the registry only to this pod.
@@ -1867,7 +1891,7 @@ modules:
     # security Context for the Contextionary Pods. The configurations are the same as setting them
     # as described here: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
     securityContext: {}
-    
+
     # It is possible to add a ServiceAccount to this module's Pods, it can be
     # used in cases where the module is in a private registry and you want to
     # give access to the registry only to this pod.


### PR DESCRIPTION
The configuration of RBAC can be done either via the config.yaml file or via environment variables. To keep it consistent with the existing authZ and authN config values, it is disabled by default and each of the available values gets referenced in the values.yaml.