### PR TITLE
Add post-installation notes

### DIFF
--- a/weaviate/files/weaviate-issues.yaml
+++ b/weaviate/files/weaviate-issues.yaml
@@ -5,10 +5,10 @@
 # Latest patch versions for each supported minor version
 # Update this section manually when new patch releases are available
 latestVersions:
-  "1.30": "1.30.1"
-  "1.29": "1.29.3"
-  "1.28": "1.28.12"
-  "1.27": "1.27.17"
+  "1.30": "1.30.3"
+  "1.29": "1.29.7"
+  "1.28": "1.28.15"
+  "1.27": "1.27.25"
   "1.26": "1.26.17"
 
 # Support status for each minor version
@@ -23,6 +23,14 @@ supportStatus:
 
 issueWarnings:
   # Available levels: "critical", "important", "warning"
+  - id: "raft-snapshot-1-27-downgrade"
+    title: "RAFT Snapshots (v1.28.13+, v1.29.5+, v1.30.2+)"
+    message: Multi-node instances of Weaviate running `1.28.13+`, `1.29.5+`, or `1.30.2+` may experience problems if downgraded to a `v1.27.x` version earlier than `1.27.26`. The cluster may not reach a **Ready** state due to a change in the way that RAFT snapshots are stored in the database. \nA fix for this issue will be released with `1.27.26`, which safely handles the downgrade path to `1.27`. \nIf you need to downgrade Weaviate to `v1.27.x`, use `1.27.26` or higher."
+    affectedVersions:
+      exact: []
+      range: ["> 1.28.13", "> 1.29.5", "> 1.30.2"]
+    level: "important"
+
   - id: "blockmax-wand-migration"
     title: "BlockMax WAND migration available"
     message: "This version sets BlockMax WAND as the default type of inverted index. If you are upgrading from an earlier version, you can migrate the inverted index for improved keyword & hybrid search. See our documentation for the official migration guide (https://weaviate.io/developers/weaviate/more-resources/migration/weaviate-1-30)."

--- a/weaviate/files/weaviate-issues.yaml
+++ b/weaviate/files/weaviate-issues.yaml
@@ -33,7 +33,7 @@ issueWarnings:
 
   - id: "backups-getting-stuck"
     title: "Backups may get stuck"
-    message: "In this version, very large backup may get stuck. This was addressed in 1.27.0 by introducing an ability to cancel backups."
+    message: "In this version, very large backups may get stuck. This was addressed in 1.27.0 by introducing an ability to cancel backups."
     affectedVersions:
       exact: []
       range: ["< 1.27.0"]

--- a/weaviate/files/weaviate-issues.yaml
+++ b/weaviate/files/weaviate-issues.yaml
@@ -5,7 +5,7 @@
 # Latest patch versions for each supported minor version
 # Update this section manually when new patch releases are available
 latestVersions:
-  "1.30": "1.30.0"
+  "1.30": "1.30.1"
   "1.29": "1.29.3"
   "1.28": "1.28.12"
   "1.27": "1.27.17"

--- a/weaviate/files/weaviate-issues.yaml
+++ b/weaviate/files/weaviate-issues.yaml
@@ -25,7 +25,7 @@ issueWarnings:
   # Available levels: "critical", "important", "warning"
   - id: "blockmax-wand-migration"
     title: "BlockMax WAND migration available"
-    message: "This version sets BlockMax WAND as the default type of inverted index. If you are migrating from an earlier version, see our migration guide."
+    message: "This version sets BlockMax WAND as the default type of inverted index. If you are upgrading from an earlier version, you can migrate the inverted index for improved keyword & hybrid search. See our documentation for the official migration guide (https://weaviate.io/developers/weaviate/more-resources/migration/weaviate-1-30)."
     affectedVersions:
       exact: ["1.30.0"]
       range: []

--- a/weaviate/files/weaviate-issues.yaml
+++ b/weaviate/files/weaviate-issues.yaml
@@ -1,0 +1,48 @@
+# Weaviate Known Issues and Version Warnings
+# This file contains known issues, bugs, and important notes for specific Weaviate versions.
+# Maintain this file to help users be aware of potential problems when using certain versions.
+
+# Latest patch versions for each supported minor version
+# Update this section manually when new patch releases are available
+latestVersions:
+  "1.30": "1.30.0"
+  "1.29": "1.29.3"
+  "1.28": "1.28.12"
+  "1.27": "1.27.17"
+  "1.26": "1.26.17"
+
+# Support status for each minor version
+# Options: "current", "maintained", "security" or "eol"
+# All other versions not listed here will show as "End of life"
+supportStatus:
+  "1.30": "current"
+  "1.29": "maintained"
+  "1.28": "maintained"
+  "1.27": "maintained"
+  "1.26": "maintained"
+
+issueWarnings:
+  # Available levels: "critical", "important", "warning"
+  - id: "blockmax-wand-migration"
+    title: "BlockMax WAND migration available"
+    message: "This version sets BlockMax WAND as the default type of inverted index. If you are migrating from an earlier version, see our migration guide."
+    affectedVersions:
+      exact: ["1.30.0"]
+      range: []
+    level: "important"
+
+  - id: "backups-getting-stuck"
+    title: "Backups may get stuck"
+    message: "In this version, very large backup may get stuck. This was addressed in 1.27.0 by introducing an ability to cancel backups."
+    affectedVersions:
+      exact: []
+      range: ["< 1.27.0"]
+    level: "warning"
+
+  - id: "strongly-suggest-upgrading"
+    title: "Suggest a different version"
+    message: "This version is not supported. Consider upgrading to a newer version."
+    affectedVersions:
+      exact: []
+      range: ["< 1.25.0"]
+    level: "critical"

--- a/weaviate/files/weaviate-issues.yaml
+++ b/weaviate/files/weaviate-issues.yaml
@@ -25,7 +25,7 @@ issueWarnings:
   # Available levels: "critical", "important", "warning"
   - id: "raft-snapshot-1-27-downgrade"
     title: "RAFT Snapshots (v1.28.13+, v1.29.5+, v1.30.2+)"
-    message: Multi-node instances of Weaviate running `1.28.13+`, `1.29.5+`, or `1.30.2+` may experience problems if downgraded to a `v1.27.x` version earlier than `1.27.26`. The cluster may not reach a **Ready** state due to a change in the way that RAFT snapshots are stored in the database. \nA fix for this issue will be released with `1.27.26`, which safely handles the downgrade path to `1.27`. \nIf you need to downgrade Weaviate to `v1.27.x`, use `1.27.26` or higher."
+    message: "CAUTION FOR DOWNGRADES: Multi-node instances of Weaviate running `1.28.13+`, `1.29.5+`, or `1.30.2+` may experience problems if downgraded to a `v1.27.x` version earlier than `1.27.26`. The cluster may not reach a **Ready** state due to a change in the way that RAFT snapshots are stored in the database. A fix for this issue will be released with `1.27.26`, which safely handles the downgrade path to `1.27`. If you need to downgrade Weaviate to `v1.27.x`, use `1.27.26` or higher."
     affectedVersions:
       exact: []
       range: ["> 1.28.13", "> 1.29.5", "> 1.30.2"]

--- a/weaviate/templates/NOTES.txt
+++ b/weaviate/templates/NOTES.txt
@@ -1,0 +1,33 @@
+Thank you for installing {{ .Chart.Name }}.
+
+Your release is named {{ .Release.Name }}.
+
+Installed Weaviate version: {{ .Values.image.tag }}
+Latest available version: {{ .Chart.AppVersion }}
+
+{{- if ne .Values.image.tag .Chart.AppVersion }}
+
+NOTE: You are not using the latest available version of Weaviate.
+{{- end }}
+
+{{- if eq .Values.image.tag "1.30.0" }}
+
+IMPORTANT: You are installing Weaviate version 1.30.0, which includes significant changes to the vector indexing mechanism.
+Please refer to the migration guide if upgrading from an earlier version.
+{{- end }}
+
+{{- if eq .Values.image.tag "1.29.0" }}
+
+IMPORTANT: You are installing Weaviate version 1.29.0, which has been deprecated and will reach end-of-life soon.
+We recommend upgrading to version 1.30.0 or newer.
+{{- end }}
+
+{{- if semverCompare "< 1.28.0" .Values.image.tag }}
+
+WARNING: You are installing an outdated version of Weaviate ({{ .Values.image.tag }}).
+Please consider upgrading to the latest version for improved features and security updates.
+{{- end }}
+
+To learn more about the release, try:
+  $ helm status {{ .Release.Name }}
+  $ helm get all {{ .Release.Name }}

--- a/weaviate/templates/NOTES.txt
+++ b/weaviate/templates/NOTES.txt
@@ -1,3 +1,5 @@
+{{- $issueWarnings := .Files.Get "files/weaviate-issues.yaml" | fromYaml -}}
+
 Thank you for installing {{ .Chart.Name }}.
 
 Your release is named {{ .Release.Name }}.
@@ -5,27 +7,48 @@ Your release is named {{ .Release.Name }}.
 Installed Weaviate version: {{ .Values.image.tag }}
 Latest available version: {{ .Chart.AppVersion }}
 
-{{- if ne .Values.image.tag .Chart.AppVersion }}
+{{- $currentMinorVersion := regexFind "^\\d+\\.\\d+" .Values.image.tag }}
 
-NOTE: You are not using the latest available version of Weaviate.
+{{- if hasKey $issueWarnings.latestVersions $currentMinorVersion -}}
+{{- $latestPatch := index $issueWarnings.latestVersions $currentMinorVersion -}}
+{{- if ne .Values.image.tag $latestPatch }}
+
+NOTE: A newer patch version ({{ $latestPatch }}) is available for your Weaviate {{ $currentMinorVersion }}.x installation.
+{{- end -}}
 {{- end }}
 
-{{- if eq .Values.image.tag "1.30.0" }}
+{{- if hasKey $issueWarnings.supportStatus $currentMinorVersion -}}
+{{- $supportStatus := index $issueWarnings.supportStatus $currentMinorVersion }}
 
-IMPORTANT: You are installing Weaviate version 1.30.0, which includes significant changes to the vector indexing mechanism.
-Please refer to the migration guide if upgrading from an earlier version.
+SUPPORT STATUS:{{ if eq $supportStatus "current" }} You are using the current minor version of Weaviate.{{ else if eq $supportStatus "maintained" }} This version of Weaviate is still maintained with regular updates.{{ else if eq $supportStatus "security" }} This version of Weaviate receives security updates only.{{ else if eq $supportStatus "eol" }} This version of Weaviate has reached end-of-life and is no longer supported.{{ end }}
+{{- else }}
+
+SUPPORT STATUS: This version of Weaviate is not listed in our supported versions and is likely end-of-life (EOL). We recommend upgrading to a supported version.
 {{- end }}
 
-{{- if eq .Values.image.tag "1.29.0" }}
+{{- range $issueWarnings.issueWarnings -}}
+  {{- /* Check if this version is affected */ -}}
+  {{- $affected := false -}}
 
-IMPORTANT: You are installing Weaviate version 1.29.0, which has been deprecated and will reach end-of-life soon.
-We recommend upgrading to version 1.30.0 or newer.
-{{- end }}
+  {{- /* Check exact matches */ -}}
+  {{- range .affectedVersions.exact -}}
+    {{- if eq $.Values.image.tag . -}}
+      {{- $affected = true -}}
+    {{- end -}}
+  {{- end -}}
 
-{{- if semverCompare "< 1.28.0" .Values.image.tag }}
+  {{- /* Check range matches */ -}}
+  {{- range .affectedVersions.range -}}
+    {{- if semverCompare . $.Values.image.tag -}}
+      {{- $affected = true -}}
+    {{- end -}}
+  {{- end -}}
 
-WARNING: You are installing an outdated version of Weaviate ({{ .Values.image.tag }}).
-Please consider upgrading to the latest version for improved features and security updates.
+  {{- /* Display warning */ -}}
+  {{- if $affected }}
+
+{{ if eq .level "critical" }}CRITICAL:{{ else if eq .level "important" }}IMPORTANT:{{ else }}WARNING:{{ end }} {{ .message }}
+  {{- end -}}
 {{- end }}
 
 To learn more about the release, try:


### PR DESCRIPTION
Add NOTES.txt and version status tracking

This PR introduces two new files:
- `templates/NOTES.txt` - Provides version information and support status on Helm install
- `files/weaviate-issues.yaml` - Contains version metadata for tracking support status

The `NOTES.txt` file displays conditional messages, containing:
- The installed version
- Latest available version
- Any later patch versions
- Support status information and
- Relevant warnings for known issues that affect the installed version.

The relevant latest patch version information, support status & warnings are pulled from `files/weaviate-issues.yaml`. This is designed to be centralised source of truth for easy maintenance.

----------------------------------------
Example: create this yaml file with a custom config:
----------------------------------------

```
# Custom configuration for Weaviate

# Specify a different Weaviate version to trigger notes
image:
  tag: 1.30.0

# Set resources
resources:
  requests:
    cpu: '500m'
    memory: '500Mi'
  limits:
    cpu: '1000m'
    memory: '1Gi'

# Use ClusterIP instead of LoadBalancer for testing
service:
  type: ClusterIP

# Set a smaller storage size for testing
storage:
  size: 10Gi
```

Then perform dry run installation e.g.:

```
helm install --dry-run --debug my-weaviate weaviate/ -f my-values.yaml
```

----------------------------------------
Example outputs
----------------------------------------

`v1.26.10`

```
Thank you for installing weaviate.

Your release is named my-weaviate.

Installed Weaviate version: 1.26.10
Latest available version: 1.30.0

NOTE: A newer patch version (1.26.17) is available for your Weaviate 1.26.x installation.

SUPPORT STATUS: This version of Weaviate is still maintained with regular updates.

WARNING: In this version, very large backups may get stuck. This was addressed in 1.27.0 by introducing an ability to cancel backups.

To learn more about the release, try:
  $ helm status my-weaviate
  $ helm get all my-weaviate
```

`v1.29.1`

```
Thank you for installing weaviate.

Your release is named my-weaviate.

Installed Weaviate version: 1.29.1
Latest available version: 1.30.0

NOTE: A newer patch version (1.29.3) is available for your Weaviate 1.29.x installation.

SUPPORT STATUS: This version of Weaviate is still maintained with regular updates.

To learn more about the release, try:
  $ helm status my-weaviate
  $ helm get all my-weaviate
```

`v1.30.0`

```
Thank you for installing weaviate.

Your release is named my-weaviate.

Installed Weaviate version: 1.30.0
Latest available version: 1.30.0

SUPPORT STATUS: You are using the current minor version of Weaviate.

IMPORTANT: This version sets BlockMax WAND as the default type of inverted index. If you are upgrading from an earlier version, you can migrate the inverted index for improved keyword & hybrid search. See our documentation for the official migration guide (https://weaviate.io/developers/weaviate/more-resources/migration/weaviate-1-30).

To learn more about the release, try:
  $ helm status my-weaviate
  $ helm get all my-weaviate
```