### PR TITLE
Make PVC name configurable

### DIFF
--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -62,7 +62,7 @@ spec:
         imagePullPolicy: "{{ .Values.image.pullPolicy }}"
         command: ["chown", "-R", "{{ .Values.containerSecurityContext.runAsUser }}:{{ .Values.containerSecurityContext.fsGroup }}", "/var/lib/weaviate"]
         volumeMounts:
-          - name: weaviate-data
+          - name: {{ .Values.storage.name }}
             mountPath: /var/lib/weaviate
       {{- end }}
       {{- end }}
@@ -465,7 +465,7 @@ spec:
         volumeMounts:
           - name: weaviate-config
             mountPath: /weaviate-config
-          - name: weaviate-data
+          - name: {{ .Values.storage.name }}
             mountPath: /var/lib/weaviate
           {{- if .Values.runtime_overrides.enabled }}
           - name: weaviate-runtime-overrides
@@ -567,7 +567,7 @@ spec:
 
   volumeClaimTemplates:
   - metadata:
-      name: weaviate-data
+      name: {{ .Values.storage.name }}
       labels:
         app.kubernetes.io/name: weaviate
         app.kubernetes.io/managed-by: {{ .Release.Service }}

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -118,10 +118,10 @@ serviceAccountName:
 # See https://github.com/weaviate/weaviate-helm/issues/175 for details.
 clusterDomain: cluster.local.
 
-# The Persistent Volume Claim settings for Weaviate. If there's a
-# storage.fullnameOverride field set, then the default pvc will not be
-# created, instead the one defined in fullnameOverride will be used
+# The Persistent Volume Claim settings for Weaviate. The given name will be used as the
+# prefix for the volumes (e.g. first replica will use {{ .Values.storage.name }}-weaviate-0)
 storage:
+  name: "weaviate-data"
   size: 32Gi
   storageClassName: ""
 


### PR DESCRIPTION
This allows users to use different volumes for storing the Weaviate data than the standard "weaviate-data-..." ones by specifying the new .Values.storage.name that this PR introduces.

E.g. in our case we need to perform a migration to a new volume and cannot do so without this change.

In the past it seems there was a possibility for this via `fullnameOverride`, but that has not actually been implemented anymore since ~v14 of the helm chart, for that reason I've also updated the corresponding part of the comment.
