### PR TITLE
Support topologySpreadConstraints

### DIFF
--- a/weaviate/templates/contextionaryDeployment.yaml
+++ b/weaviate/templates/contextionaryDeployment.yaml
@@ -68,6 +68,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with index $module "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with index $module "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}

--- a/weaviate/templates/gpt4allInferenceDeployment.yaml
+++ b/weaviate/templates/gpt4allInferenceDeployment.yaml
@@ -57,6 +57,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with index $module "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with index $module "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}

--- a/weaviate/templates/img2vecNeuralDeployment.yaml
+++ b/weaviate/templates/img2vecNeuralDeployment.yaml
@@ -68,6 +68,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with index $module "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with index $module "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}

--- a/weaviate/templates/multi2vecBindDeployment.yaml
+++ b/weaviate/templates/multi2vecBindDeployment.yaml
@@ -68,6 +68,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with index $module "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with index $module "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}

--- a/weaviate/templates/multi2vecClipDeployment.yaml
+++ b/weaviate/templates/multi2vecClipDeployment.yaml
@@ -68,6 +68,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with index $module "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with index $module "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}

--- a/weaviate/templates/nerTransformersDeployment.yaml
+++ b/weaviate/templates/nerTransformersDeployment.yaml
@@ -68,6 +68,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with index $module "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with index $module "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}

--- a/weaviate/templates/qnaTransformersDeployment.yaml
+++ b/weaviate/templates/qnaTransformersDeployment.yaml
@@ -68,6 +68,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with index $module "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with index $module "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}

--- a/weaviate/templates/rerankerTransformersDeployment.yaml
+++ b/weaviate/templates/rerankerTransformersDeployment.yaml
@@ -68,6 +68,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with index $module "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with index $module "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}

--- a/weaviate/templates/sumTransformersDeployment.yaml
+++ b/weaviate/templates/sumTransformersDeployment.yaml
@@ -68,6 +68,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with index $module "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with index $module "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}

--- a/weaviate/templates/textSpellcheckDeployment.yaml
+++ b/weaviate/templates/textSpellcheckDeployment.yaml
@@ -57,6 +57,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with index $module "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with index $module "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}

--- a/weaviate/templates/transformersInferenceDeployment.yaml
+++ b/weaviate/templates/transformersInferenceDeployment.yaml
@@ -91,6 +91,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with index $module "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with index $module "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
@@ -201,6 +205,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with index $passage "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with index $passage "tolerations" | default .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}
@@ -306,6 +314,10 @@ spec:
       {{- end }}
       {{- with index $query "affinity" | default .Values.affinity }}
       affinity:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with index $query "topologySpreadConstraints" | default .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
         {{ toYaml . | nindent 8 }}
       {{- end }}
       {{- with index $query "tolerations" | default .Values.tolerations }}

--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -556,6 +556,10 @@ spec:
       affinity:
         {{ toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.topologySpreadConstraints }}
+      topologySpreadConstraints:
+        {{ toYaml . | nindent 8 }}
+      {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
         {{ toYaml . | nindent 8 }}

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -609,12 +609,12 @@ modules:
 
     # You can guide where the pods are scheduled on a per-module basis,
     # as well as for Weaviate overall. Each module accepts nodeSelector,
-    # tolerations, and affinity configuration. If it is set on a per-
-    # module basis, this configuration overrides the global config.
-
+    # tolerations, affinity, and topology spread configuration. If it is 
+    # set on a per-module basis, this configuration overrides the global config.
     nodeSelector:
     tolerations:
     affinity:
+    topologySpreadConstraints:
 
   # The text2vec-transformers modules uses neural networks, such as BERT,
   # DistilBERT, etc. to dynamically compute vector embeddings based on the
@@ -695,11 +695,12 @@ modules:
 
     # You can guide where the pods are scheduled on a per-module basis,
     # as well as for Weaviate overall. Each module accepts nodeSelector,
-    # tolerations, and affinity configuration. If it is set on a per-
-    # module basis, this configuration overrides the global config.
+    # tolerations, affinity, and topology spread configuration. If it is 
+    # set on a per-module basis, this configuration overrides the global config.
     nodeSelector:
     tolerations:
     affinity:
+    topologySpreadConstraints:
 
     passageQueryServices:
       passage:
@@ -768,12 +769,12 @@ modules:
 
         # You can guide where the pods are scheduled on a per-module basis,
         # as well as for Weaviate overall. Each module accepts nodeSelector,
-        # tolerations, and affinity configuration. If it is set on a per-
-        # module basis, this configuration overrides the global config.
-
+        # tolerations, affinity, and topology spread configuration. If it is 
+        # set on a per-module basis, this configuration overrides the global config.
         nodeSelector:
         tolerations:
         affinity:
+        topologySpreadConstraints:
 
       query:
         enabled: false
@@ -842,12 +843,12 @@ modules:
 
         # You can guide where the pods are scheduled on a per-module basis,
         # as well as for Weaviate overall. Each module accepts nodeSelector,
-        # tolerations, and affinity configuration. If it is set on a per-
-        # module basis, this configuration overrides the global config.
-
+        # tolerations, affinity, and topology spread configuration. If it is 
+        # set on a per-module basis, this configuration overrides the global config.
         nodeSelector:
         tolerations:
         affinity:
+        topologySpreadConstraints:
 
   # The text2vec-gpt4all is a vectorizer module that allows to run ML models from
   # nomic-ai/gpt4all: https://docs.gpt4all.io/gpt4all_python_embedding.html
@@ -904,12 +905,12 @@ modules:
 
     # You can guide where the pods are scheduled on a per-module basis,
     # as well as for Weaviate overall. Each module accepts nodeSelector,
-    # tolerations, and affinity configuration. If it is set on a per-
-    # module basis, this configuration overrides the global config.
-
+    # tolerations, affinity, and topology spread configuration. If it is 
+    # set on a per-module basis, this configuration overrides the global config.
     nodeSelector:
     tolerations:
     affinity:
+    topologySpreadConstraints:
 
   # The text2vec-openai module uses OpenAI Embeddings API
   # to dynamically compute vector embeddings based on the
@@ -1430,12 +1431,12 @@ modules:
 
     # You can guide where the pods are scheduled on a per-module basis,
     # as well as for Weaviate overall. Each module accepts nodeSelector,
-    # tolerations, and affinity configuration. If it is set on a per-
-    # module basis, this configuration overrides the global config.
-
+    # tolerations, affinity, and topology spread configuration. If it is 
+    # set on a per-module basis, this configuration overrides the global config.
     nodeSelector:
     tolerations:
     affinity:
+    topologySpreadConstraints:
 
   # The qna-openai module uses OpenAI Completions API
   # to dynamically answer given questions.
@@ -1700,12 +1701,12 @@ modules:
 
     # You can guide where the pods are scheduled on a per-module basis,
     # as well as for Weaviate overall. Each module accepts nodeSelector,
-    # tolerations, and affinity configuration. If it is set on a per-
-    # module basis, this configuration overrides the global config.
-
+    # tolerations, affinity, and topology spread configuration. If it is 
+    # set on a per-module basis, this configuration overrides the global config.
     nodeSelector:
     tolerations:
     affinity:
+    topologySpreadConstraints:
 
   # The reranker-cohere module uses Cohere API
   # to dynamically compute a score for the relevance
@@ -1827,12 +1828,12 @@ modules:
 
     # You can guide where the pods are scheduled on a per-module basis,
     # as well as for Weaviate overall. Each module accepts nodeSelector,
-    # tolerations, and affinity configuration. If it is set on a per-
-    # module basis, this configuration overrides the global config.
-
+    # tolerations, affinity, and topology spread configuration. If it is 
+    # set on a per-module basis, this configuration overrides the global config.
     nodeSelector:
     tolerations:
     affinity:
+    topologySpreadConstraints:
 
   # The text-spellcheck module uses spellchecker library to check
   # misspellings in a given text
@@ -1884,12 +1885,12 @@ modules:
 
     # You can guide where the pods are scheduled on a per-module basis,
     # as well as for Weaviate overall. Each module accepts nodeSelector,
-    # tolerations, and affinity configuration. If it is set on a per-
-    # module basis, this configuration overrides the global config.
-
+    # tolerations, affinity, and topology spread configuration. If it is 
+    # set on a per-module basis, this configuration overrides the global config.
     nodeSelector:
     tolerations:
     affinity:
+    topologySpreadConstraints:
 
   # The ner-transformers module uses spellchecker library to check
   # misspellings in a given text
@@ -1958,12 +1959,12 @@ modules:
 
     # You can guide where the pods are scheduled on a per-module basis,
     # as well as for Weaviate overall. Each module accepts nodeSelector,
-    # tolerations, and affinity configuration. If it is set on a per-
-    # module basis, this configuration overrides the global config.
-
+    # tolerations, affinity, and topology spread configuration. If it is 
+    # set on a per-module basis, this configuration overrides the global config.
     nodeSelector:
     tolerations:
     affinity:
+    topologySpreadConstraints:
 
   # The sum-transformers module makes result texts summarizations
   sum-transformers:
@@ -2029,12 +2030,12 @@ modules:
 
     # You can guide where the pods are scheduled on a per-module basis,
     # as well as for Weaviate overall. Each module accepts nodeSelector,
-    # tolerations, and affinity configuration. If it is set on a per-
-    # module basis, this configuration overrides the global config.
-
+    # tolerations, affinity, and topology spread configuration. If it is 
+    # set on a per-module basis, this configuration overrides the global config.
     nodeSelector:
     tolerations:
     affinity:
+    topologySpreadConstraints:
 
   # by choosing the default vectorizer module, you can tell Weaviate to always
   # use this module as the vectorizer if nothing else is specified. Can be
@@ -2073,6 +2074,8 @@ nodeSelector:
 tolerations:
 
 hostAliases:
+
+topologySpreadConstraints:
 
 affinity:
   podAntiAffinity:


### PR DESCRIPTION
Currently it is not possible to distribute the deployment in different availability zones (AZ).

Say I have `replicas: 3` and three zones:

```
AZ1: Node1, Node2
AZ2: Node3, Node4
AZ3: Node5, Node6
```

The following config can currently happen:
Replica 1: Node 1 / **AZ1**
Replica 2: Node 2 / **AZ1**
Replica 3: Node 3 / AZ2

I want the scheduler instead to prefer this config:
Replica 1: Node 1 / **AZ1**
Replica 2: Node 3 / **AZ2**
Replica 3: Node 5 / AZ3

By supporting topologySpreadConstraints, this is possible.