### PR TITLE
Add support for collection export

### DIFF
--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -441,6 +441,8 @@ function check_creates_template() {
   check_setting_has_value "--set collectionExport.enabled=true" "name: EXPORT_ENABLED" "value: \"true\""
   check_setting_has_value "--set collectionExport.enabled=true" "name: EXPORT_DEFAULT_BUCKET" "value: \"weaviate-export\""
   check_setting_has_value "--set collectionExport.enabled=true --set collectionExport.envconfig.EXPORT_DEFAULT_BUCKET=my-custom-bucket" "name: EXPORT_DEFAULT_BUCKET" "value: \"my-custom-bucket\""
+  check_no_setting "--set collectionExport.enabled=true" "name: EXPORT_DEFAULT_PATH"
+  check_setting_has_value "--set collectionExport.enabled=true --set collectionExport.envconfig.EXPORT_DEFAULT_PATH=path/inside/bucket" "name: EXPORT_DEFAULT_PATH" "value: \"path/inside/bucket\""
 
   echo "Tests successful."
 )

--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -435,5 +435,12 @@ function check_creates_template() {
   check_string_existence "--set readinessProbe.probeType=exec --set readinessProbe.probe.exec.command={test-probe-cmd}" "command:"
   check_string_existence "--set readinessProbe.probeType=exec --set readinessProbe.probe.exec.command={test-probe-cmd}" "test-probe-cmd"
 
+  # Collection export tests
+  check_no_setting "" "name: EXPORT_ENABLED"
+  check_no_setting "" "name: EXPORT_DEFAULT_BUCKET"
+  check_setting_has_value "--set collectionExport.enabled=true" "name: EXPORT_ENABLED" "value: \"true\""
+  check_setting_has_value "--set collectionExport.enabled=true" "name: EXPORT_DEFAULT_BUCKET" "value: \"weaviate-export\""
+  check_setting_has_value "--set collectionExport.enabled=true --set collectionExport.envconfig.EXPORT_DEFAULT_BUCKET=my-custom-bucket" "name: EXPORT_DEFAULT_BUCKET" "value: \"my-custom-bucket\""
+
   echo "Tests successful."
 )

--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -357,12 +357,12 @@ function check_creates_template() {
   check_setting_has_value "--set replicas=9 --set env.RAFT_METADATA_ONLY_VOTERS=true" "name: RAFT_METADATA_ONLY_VOTERS" "value: \"true\""
   check_setting_has_value "--set replicas=3 --set env.RAFT_METADATA_ONLY_VOTERS=false" "name: RAFT_BOOTSTRAP_EXPECT" "value: \"3\""
 
-  _settingPassageQueryOn="--set modules.text2vec-contextionary.enabled=false --set modules.text2vec-transformers.passageQueryServices.passage.enabled=true --set modules.text2vec-transformers.passageQueryServices.query.enabled=true"
+  _settingPassageQueryOn="--namespace default --set modules.text2vec-contextionary.enabled=false --set modules.text2vec-transformers.passageQueryServices.passage.enabled=true --set modules.text2vec-transformers.passageQueryServices.query.enabled=true"
   check_setting_has_value "$_settingPassageQueryOn" "name: TRANSFORMERS_PASSAGE_INFERENCE_API" "value: http://transformers-inference-passage.default.svc.cluster.local.:8080"
   check_setting_has_value "$_settingPassageQueryOn" "name: TRANSFORMERS_QUERY_INFERENCE_API" "value: http://transformers-inference-query.default.svc.cluster.local.:8080"
   check_no_setting "$_settingPassageQueryOn" "name: TRANSFORMERS_INFERENCE_API"
 
-  _settingPassageQueryOff="--set modules.text2vec-contextionary.enabled=false --set modules.text2vec-transformers.enabled=true"
+  _settingPassageQueryOff="--namespace default --set modules.text2vec-contextionary.enabled=false --set modules.text2vec-transformers.enabled=true"
   check_setting_has_value "$_settingPassageQueryOff" "name: TRANSFORMERS_INFERENCE_API" "value: http://transformers-inference.default.svc.cluster.local.:8080"
   check_no_setting "$_settingPassageQueryOff" "name: TRANSFORMERS_PASSAGE_INFERENCE_API"
   check_no_setting "$_settingPassageQueryOff" "name: TRANSFORMERS_QUERY_INFERENCE_API"
@@ -438,11 +438,14 @@ function check_creates_template() {
   # Collection export tests
   check_no_setting "" "name: EXPORT_ENABLED"
   check_no_setting "" "name: EXPORT_DEFAULT_BUCKET"
+  check_no_setting "" "name: EXPORT_DEFAULT_PATH"
   check_setting_has_value "--set collectionExport.enabled=true" "name: EXPORT_ENABLED" "value: \"true\""
   check_setting_has_value "--set collectionExport.enabled=true" "name: EXPORT_DEFAULT_BUCKET" "value: \"weaviate-export\""
   check_setting_has_value "--set collectionExport.enabled=true --set collectionExport.envconfig.EXPORT_DEFAULT_BUCKET=my-custom-bucket" "name: EXPORT_DEFAULT_BUCKET" "value: \"my-custom-bucket\""
-  check_no_setting "--set collectionExport.enabled=true" "name: EXPORT_DEFAULT_PATH"
+  check_setting_has_value "--set collectionExport.enabled=true" "name: EXPORT_DEFAULT_PATH" "value: \"\""
   check_setting_has_value "--set collectionExport.enabled=true --set collectionExport.envconfig.EXPORT_DEFAULT_PATH=path/inside/bucket" "name: EXPORT_DEFAULT_PATH" "value: \"path/inside/bucket\""
+  check_no_setting "--set collectionExport.enabled=true" "name: EXPORT_PARALLELISM"
+  check_setting_has_value "--set collectionExport.enabled=true --set collectionExport.envconfig.EXPORT_PARALLELISM=4" "name: EXPORT_PARALLELISM" "value: \"4\""
 
   echo "Tests successful."
 )

--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -494,6 +494,7 @@ spec:
           - name: MCP_SERVER_CONFIG_PATH
             value: "/mcp-config/mcp-config.yaml"
           {{- end }}
+          {{- end }}
           {{- if index .Values "collectionExport" "enabled" }}
           - name: EXPORT_ENABLED
             value: "true"

--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -494,6 +494,15 @@ spec:
           - name: MCP_SERVER_CONFIG_PATH
             value: "/mcp-config/mcp-config.yaml"
           {{- end }}
+          {{- if index .Values "collectionExport" "enabled" }}
+          - name: EXPORT_ENABLED
+            value: "true"
+            {{- if index .Values "collectionExport" "envconfig" }}
+              {{- range $key, $value := index .Values "collectionExport" "envconfig" }}
+          - name: {{ $key }}
+            value: {{ $value | quote }}
+              {{- end }}
+            {{- end }}
           {{- end }}
           - name: CLUSTER_JOIN
             value: {{ .Values.service.name }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -615,6 +615,10 @@ collectionExport:
     # The bucket must exist before enabling collection export, otherwise exports will fail.
     EXPORT_DEFAULT_BUCKET: weaviate-export
 
+    # Optional setting. Defaults to empty string.
+    # Set this option if you want to save exports to a given path inside the bucket.
+    # EXPORT_DEFAULT_PATH: path/inside/bucket
+
 # modules are extensions to Weaviate, they can be used to support various
 # ML-models, but also other features unrelated to model inference.
 # An inference/vectorizer module is not required, you can also run without any

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -607,6 +607,14 @@ backups:
     #   AZURE_STORAGE_CONNECTION_STRING: name-of-the-k8s-secret-containing-connection-string
 
 
+# Configure collection export
+collectionExport:
+  enabled: false
+  envconfig:
+    # Configure bucket where exports should be saved, this setting is mandatory.
+    # The bucket must exist before enabling collection export, otherwise exports will fail.
+    EXPORT_DEFAULT_BUCKET: weaviate-export
+
 # modules are extensions to Weaviate, they can be used to support various
 # ML-models, but also other features unrelated to model inference.
 # An inference/vectorizer module is not required, you can also run without any

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -615,9 +615,13 @@ collectionExport:
     # The bucket must exist before enabling collection export, otherwise exports will fail.
     EXPORT_DEFAULT_BUCKET: weaviate-export
 
-    # Optional setting. Defaults to empty string.
-    # Set this option if you want to save exports to a given path inside the bucket.
-    # EXPORT_DEFAULT_PATH: path/inside/bucket
+    # Required setting. Bucket path in which to save exports. Defaults to empty string.
+    # Set this option if you want to save exports to a given path inside the bucket. Must be a valid bucket path.
+    EXPORT_DEFAULT_PATH: ""
+
+    # Optional setting. Defaults to 0 (GOMAXPROCS at runtime).
+    # Set this option to control the number of concurrent scan workers per export.
+    # EXPORT_PARALLELISM: 0
 
 # modules are extensions to Weaviate, they can be used to support various
 # ML-models, but also other features unrelated to model inference.


### PR DESCRIPTION
## What's being changed

Adds Helm chart support for Weaviate's collection export feature, introduced in weaviate/weaviate#10958.

**`values.yaml`** — new top-level `collectionExport` section (mirrors the pattern of `backups` and `offload`):
- `collectionExport.enabled` — gates the feature; when `true`, injects `EXPORT_ENABLED=true` into the pod
- `collectionExport.envconfig.EXPORT_DEFAULT_BUCKET` — required bucket name (defaults to `weaviate-export`); the bucket must exist before enabling, otherwise exports will fail
- `collectionExport.envconfig.EXPORT_DEFAULT_PATH` — optional path prefix inside the bucket (commented out, defaults to empty)
- `collectionExport.envconfig.EXPORT_PARALLELISM` — optional number of concurrent scan workers per export (commented out, defaults to `0` = GOMAXPROCS at runtime)

**`templates/weaviateStatefulset.yaml`** — renders the env vars when `collectionExport.enabled=true`; all other `collectionExport.envconfig` keys are forwarded as-is, so future env vars require no template changes.

**`.cicd/test.sh`** — test cases covering:
- `EXPORT_ENABLED` and `EXPORT_DEFAULT_BUCKET` are absent by default
- Both are injected when the feature is enabled
- Custom bucket name overrides the default
- `EXPORT_DEFAULT_PATH` and `EXPORT_PARALLELISM` are absent by default but can be set via `envconfig`
- Pass the namespace in certain tests, as otherwise the CI will start failing once the github runners upgrade from Helm v3 to v4.