### PR TITLE
Pin dependencies using SHA hashes instead of tags

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -20,7 +20,7 @@ jobs:
       SKIPPED_VULN: ""
     if: ${{ !github.event.pull_request.head.repo.fork }}  # no PRs from fork
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Skip vulnerabilities
         if: ${{ env.SKIPPED_VULN != '' }}
         run: |
@@ -37,7 +37,7 @@ jobs:
       - name: Pull Docker image
         run: docker pull ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}
       - name: Run Trivy vulnerability scanner for the built image
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: '${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_REPO }}:${{ env.IMAGE_TAG }}'
           exit-code: '1'
@@ -48,7 +48,7 @@ jobs:
     name: Test and release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
       - name: Test
         run: ./.cicd/test.sh
       - name: Release
@@ -56,7 +56,7 @@ jobs:
         run: .cicd/release.sh
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@26994186c0ac3ef5cae75ac16aa32e8153525f77 # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -72,13 +72,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           # chartpress requires git history to set chart version and image tags
           # correctly
           fetch-depth: 0
 
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # v4
         with:
           python-version: "3.10"
 
@@ -88,7 +88,7 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - name: Install Helm
-        uses: azure/setup-helm@v3
+        uses: azure/setup-helm@5119fcb9089d432beecbf79bb2c7915207344b78 # v3
         with:
           version: v3.10.2
 


### PR DESCRIPTION
Pin GitHub Actions dependencies to commit SHAs instead of mutable version tags for supply chain security.

| Action | SHA | Version |
|--------|-----|---------|
| `actions/checkout` | `34e11487...` | v4 |
| `actions/checkout` | `f43a0e5f...` | v3 (2 occurrences) |
| `aquasecurity/trivy-action` | `57a97c7e...` | 0.35.0 |
| `softprops/action-gh-release` | `26994186...` | v1 |
| `actions/setup-python` | `7f4fc3e2...` | v4 |
| `azure/setup-helm` | `5119fcb9...` | v3 |
