### PR TITLE
Add support for the namespaces feature

### DIFF
--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -450,5 +450,28 @@ function check_creates_template() {
   check_no_setting "--set collectionExport.enabled=true" "name: EXPORT_PARALLELISM"
   check_setting_has_value "--set collectionExport.enabled=true --set collectionExport.envconfig.EXPORT_PARALLELISM=4" "name: EXPORT_PARALLELISM" "value: \"4\""
 
+  # Namespaces feature tests
+  # Default (namespaces disabled): neither NAMESPACES_ENABLED nor DISABLE_GRAPHQL should be templated.
+  check_no_setting "" "name: NAMESPACES_ENABLED"
+  check_no_setting "" "name: DISABLE_GRAPHQL"
+  check_no_setting "--set namespaces.enabled=false" "name: NAMESPACES_ENABLED"
+  check_no_setting "--set namespaces.enabled=false" "name: DISABLE_GRAPHQL"
+  # Namespaces enabled: flag emits both required envs.
+  check_setting_has_value "--set namespaces.enabled=true" "name: NAMESPACES_ENABLED" "value: \"true\""
+  check_setting_has_value "--set namespaces.enabled=true" "name: DISABLE_GRAPHQL" "value: \"true\""
+  # Namespaces enabled end-to-end: flag + apikey + RBAC (configured via the chart's
+  # authentication/authorization values) must render cleanly together.
+  _settingNamespacesFull="--set namespaces.enabled=true --set authentication.apikey.enabled=true --set authentication.apikey.allowed_keys[0]=admin-key --set authentication.apikey.users[0]=admin --set authorization.rbac.enabled=true --set authorization.rbac.root_users[0]=admin"
+  check_setting_has_value "$_settingNamespacesFull" "name: NAMESPACES_ENABLED" "value: \"true\""
+  check_setting_has_value "$_settingNamespacesFull" "name: DISABLE_GRAPHQL" "value: \"true\""
+  check_string_existence "$_settingNamespacesFull" "allowed_keys:"
+  check_string_existence "$_settingNamespacesFull" "admin-key"
+  check_string_existence "$_settingNamespacesFull" "root_users:"
+  # OIDC namespace/global principal claims must propagate to the weaviate-config ConfigMap when set.
+  _settingOidcClaims="--set authentication.oidc.namespace_claim=weaviate_namespace --set authentication.oidc.global_principal_claim=weaviate_global --set authentication.oidc.skip_client_id_check=true"
+  check_string_existence "$_settingOidcClaims" "namespace_claim: weaviate_namespace"
+  check_string_existence "$_settingOidcClaims" "global_principal_claim: weaviate_global"
+  check_string_existence "$_settingOidcClaims" "skip_client_id_check: true"
+
   echo "Tests successful."
 )

--- a/.cicd/test.sh
+++ b/.cicd/test.sh
@@ -451,19 +451,28 @@ function check_creates_template() {
   check_setting_has_value "--set collectionExport.enabled=true --set collectionExport.envconfig.EXPORT_PARALLELISM=4" "name: EXPORT_PARALLELISM" "value: \"4\""
 
   # Namespaces feature tests
-  # Default (namespaces disabled): neither NAMESPACES_ENABLED nor DISABLE_GRAPHQL should be templated.
+  # Default (namespaces disabled): none of the namespaces-coupled envs should be templated.
+  # REPLICATION_MAXIMUM_FACTOR is only forced by the namespaces block, so it must be absent by default.
   check_no_setting "" "name: NAMESPACES_ENABLED"
   check_no_setting "" "name: DISABLE_GRAPHQL"
+  check_no_setting "" "name: REPLICATION_MAXIMUM_FACTOR"
   check_no_setting "--set namespaces.enabled=false" "name: NAMESPACES_ENABLED"
   check_no_setting "--set namespaces.enabled=false" "name: DISABLE_GRAPHQL"
-  # Namespaces enabled: flag emits both required envs.
+  check_no_setting "--set namespaces.enabled=false" "name: REPLICATION_MAXIMUM_FACTOR"
+  # Namespaces enabled: flag emits all required envs. The server fatals on startup unless
+  # REPLICATION_MAXIMUM_FACTOR=1 when NAMESPACES_ENABLED=true, so the chart pins it to "1".
   check_setting_has_value "--set namespaces.enabled=true" "name: NAMESPACES_ENABLED" "value: \"true\""
   check_setting_has_value "--set namespaces.enabled=true" "name: DISABLE_GRAPHQL" "value: \"true\""
+  check_setting_has_value "--set namespaces.enabled=true" "name: REPLICATION_MAXIMUM_FACTOR" "value: \"1\""
+  # The pinned REPLICATION_MAXIMUM_FACTOR=1 is rendered after the generic env loop, so it overrides
+  # any user-supplied env.REPLICATION_MAXIMUM_FACTOR (Kubernetes keeps the last duplicate env entry).
+  check_setting_has_value "--set namespaces.enabled=true --set env.REPLICATION_MAXIMUM_FACTOR=3" "name: REPLICATION_MAXIMUM_FACTOR" "value: \"1\""
   # Namespaces enabled end-to-end: flag + apikey + RBAC (configured via the chart's
   # authentication/authorization values) must render cleanly together.
   _settingNamespacesFull="--set namespaces.enabled=true --set authentication.apikey.enabled=true --set authentication.apikey.allowed_keys[0]=admin-key --set authentication.apikey.users[0]=admin --set authorization.rbac.enabled=true --set authorization.rbac.root_users[0]=admin"
   check_setting_has_value "$_settingNamespacesFull" "name: NAMESPACES_ENABLED" "value: \"true\""
   check_setting_has_value "$_settingNamespacesFull" "name: DISABLE_GRAPHQL" "value: \"true\""
+  check_setting_has_value "$_settingNamespacesFull" "name: REPLICATION_MAXIMUM_FACTOR" "value: \"1\""
   check_string_existence "$_settingNamespacesFull" "allowed_keys:"
   check_string_existence "$_settingNamespacesFull" "admin-key"
   check_string_existence "$_settingNamespacesFull" "root_users:"

--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -517,6 +517,8 @@ spec:
             value: "true"
           - name: DISABLE_GRAPHQL
             value: "true"
+          - name: REPLICATION_MAXIMUM_FACTOR
+            value: "1"
           {{- end }}
           - name: CLUSTER_JOIN
             value: {{ .Values.service.name }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}

--- a/weaviate/templates/weaviateStatefulset.yaml
+++ b/weaviate/templates/weaviateStatefulset.yaml
@@ -512,6 +512,12 @@ spec:
               {{- end }}
             {{- end }}
           {{- end }}
+          {{- if index .Values "namespaces" "enabled" }}
+          - name: NAMESPACES_ENABLED
+            value: "true"
+          - name: DISABLE_GRAPHQL
+            value: "true"
+          {{- end }}
           - name: CLUSTER_JOIN
             value: {{ .Values.service.name }}-headless.{{ .Release.Namespace }}.svc.{{ .Values.clusterDomain }}
         ports:

--- a/weaviate/values.yaml
+++ b/weaviate/values.yaml
@@ -274,6 +274,9 @@ authentication:
     # username_claim: ''
     # groups_claim: ''
     # client_id: ''
+    # skip_client_id_check: false
+    # namespace_claim: ''
+    # global_principal_claim: ''
 
 authorization:
   rbac:
@@ -296,6 +299,9 @@ query_defaults:
   limit: 100
 debug: false
 
+# Enable namespaces support in the weaviate cluster. Once enabled, the cluster can't be migrated to a non-namespaced cluster and vice versa.
+namespaces:
+  enabled: false
 
 # Insert any custom environment variables or envSecrets by putting the exact name
 # and desired value into the settings below. Any env name passed will be automatically


### PR DESCRIPTION
## Summary
- Adds a top-level `namespaces.enabled` flag (default `false`). When enabled, the statefulset emits `NAMESPACES_ENABLED=true`, `DISABLE_GRAPHQL=true`, and `REPLICATION_MAXIMUM_FACTOR=1` together — Weaviate refuses to start (`fatal`) unless all three are aligned with `NAMESPACES_ENABLED`.
- `REPLICATION_MAXIMUM_FACTOR=1` is a hard server precondition, not a tunable, so it is pinned in the chart rather than exposed as a configurable value (a value other than `1` would crash every pod when namespaces is on).
- Exposes the OIDC claim fields needed for namespace-aware identities (`namespace_claim`, `global_principal_claim`, `skip_client_id_check`) as commented-out entries under `authentication.oidc`. They flow through `toYaml .Values.authentication` into the `weaviate-config` ConfigMap when set.
- Adds chart tests covering: defaults (envs absent), explicit `namespaces.enabled=false`, `namespaces.enabled=true` (all three envs rendered), the `REPLICATION_MAXIMUM_FACTOR` override case, namespaces + apikey + RBAC end-to-end, and OIDC claim propagation into the ConfigMap.

## Notes for reviewers
- The new env block sits **after** the generic `env.*` loop in `weaviateStatefulset.yaml`, so user combinations like `--set namespaces.enabled=true --set env.DISABLE_GRAPHQL=false` or `--set env.REPLICATION_MAXIMUM_FACTOR=3` still end up with the server-required values (last-value-wins: runc dedupes duplicate env vars keeping the last occurrence), matching the server's invariant.
- The change is opt-in: a chart upgrade with no value overrides produces no diff in the rendered StatefulSet.

## Test plan
- [x] `bash .cicd/test.sh` passes locally (exit 0, "Tests successful."), including the namespaces + `REPLICATION_MAXIMUM_FACTOR` assertions.
- [x] `helm template . --set namespaces.enabled=true` shows all three required envs.
- [x] `helm template . --set namespaces.enabled=true --set env.REPLICATION_MAXIMUM_FACTOR=3` renders the pinned `REPLICATION_MAXIMUM_FACTOR=1` last, overriding the user value.
- [x] `helm template . --set authentication.oidc.namespace_claim=... --set authentication.oidc.global_principal_claim=...` renders the claim fields into the ConfigMap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)